### PR TITLE
Add Umami v3 support, API client, and bug fixes

### DIFF
--- a/CONTRIBUTION_PLAN.md
+++ b/CONTRIBUTION_PLAN.md
@@ -1,0 +1,1109 @@
+# WP-Umami Contribution Plan: Umami v3 Readiness + Issue Resolution
+
+> **Date:** 2026-01-29
+> **Plugin Version:** 0.8.3
+> **Target:** Full Umami v3 support with v2 backwards compatibility
+> **Repo:** [Ancocodet/wp-umami](https://github.com/Ancocodet/wp-umami)
+
+---
+
+## Table of Contents
+
+1. [Current State Assessment](#1-current-state-assessment)
+2. [v2 vs v3 Gap Analysis](#2-v2-vs-v3-gap-analysis)
+3. [Issue Triage & Priority](#3-issue-triage--priority)
+4. [Implementation Phases](#4-implementation-phases)
+5. [Phase 1: Foundation & Bug Fixes](#phase-1-foundation--bug-fixes)
+6. [Phase 2: v3 Tracker Attributes](#phase-2-v3-tracker-attributes)
+7. [Phase 3: Umami API Integration](#phase-3-umami-api-integration)
+8. [Phase 4: WooCommerce Revenue Tracking](#phase-4-woocommerce-revenue-tracking)
+9. [Phase 5: Proxy Mode](#phase-5-proxy-mode)
+10. [Phase 6: Dashboard Panel](#phase-6-dashboard-panel)
+11. [Testing Strategy](#7-testing-strategy)
+12. [Backwards Compatibility Contract](#8-backwards-compatibility-contract)
+13. [File-by-File Change Map](#9-file-by-file-change-map)
+14. [Risk Register](#10-risk-register)
+
+---
+
+## 1. Current State Assessment
+
+### Architecture
+
+The plugin is lightweight — 5 PHP classes, no server-side API calls:
+
+| File | Purpose |
+|------|---------|
+| `wp-umami.php` | Entry point, loads Manager + Settings |
+| `inc/class-manager.php` | Injects tracking `<script>` into `wp_footer`, comment event tracking |
+| `inc/class-settings.php` | WordPress Settings API integration, admin page |
+| `inc/class-options.php` | Options CRUD with migration from old option name |
+| `inc/class-dashboard-widget.php` | Dashboard widget linking to Umami instance |
+| `inc/templates/settings-page.php` | Settings form HTML |
+
+### What the Plugin Does Today
+
+- Injects Umami tracking script (`<script async defer src="..." data-website-id="...">`)
+- Supports these `data-*` attributes: `data-do-not-track`, `data-auto-track`, `data-cache`, `data-host-url`
+- Optionally tracks comment form submissions via `data-umami-event` attributes
+- Dashboard widget with link to Umami instance
+- Ignores admin users (configurable)
+- Options migration from `umami_options` → `integrate_umami_options`
+
+### What the Plugin Does NOT Do
+
+- No server-side Umami API calls (no authentication, no data fetching)
+- No WooCommerce integration
+- No proxy mode for ad-blocker bypass
+- No support for v3-specific tracker attributes (`data-tag`, `data-domains`, `data-exclude-search`, `data-exclude-hash`, `data-before-send`)
+- No dashboard analytics panel (just a link widget)
+- No Umami Cloud support guidance
+
+---
+
+## 2. v2 vs v3 Gap Analysis
+
+### Tracker Script Attributes
+
+| Attribute | v2 | v3 | Plugin Status |
+|-----------|----|----|---------------|
+| `data-website-id` | ✅ | ✅ | ✅ Supported |
+| `data-host-url` | ✅ | ✅ | ✅ Supported |
+| `data-auto-track` | ✅ | ✅ | ✅ Supported |
+| `data-do-not-track` | ✅ | ✅ | ✅ Supported (marked deprecated for v2 in UI, but actually works in both) |
+| `data-cache` | ✅ (removed in later v2) | ❌ Removed | ⚠️ Supported but should be deprecated/removed |
+| `data-domains` | ✅ | ✅ | ❌ **Missing** |
+| `data-tag` | ✅ | ✅ | ❌ **Missing** (Issue #53) |
+| `data-exclude-search` | ❌ | ✅ New | ❌ **Missing** |
+| `data-exclude-hash` | ❌ | ✅ New | ❌ **Missing** |
+| `data-before-send` | ❌ | ✅ New | ❌ **Missing** (advanced) |
+
+### API Endpoints
+
+| Feature | v2 Endpoint | v3 Endpoint | Breaking Change? |
+|---------|-------------|-------------|-----------------|
+| Authentication | `POST /api/auth/login` | `POST /api/auth/login` | No |
+| Send data | `POST /api/send` | `POST /api/send` | No |
+| List websites | `GET /api/websites` | `GET /api/websites` | Minor: v3 adds `includeTeams` param |
+| Website stats | `GET /api/websites/:id/stats` | `GET /api/websites/:id/stats` | v3 adds `comparison` field |
+| Active visitors | `GET /api/websites/:id/active` | `GET /api/websites/:id/active` | No |
+| Events | `GET /api/websites/:id/events` | `GET /api/websites/:id/events` | No |
+| Sessions | `GET /api/websites/:id/sessions` | `GET /api/websites/:id/sessions` | No |
+| Realtime | — | `GET /api/realtime/:id` | New in v3 |
+| Pixels | — | `GET /api/pixels` | New in v3 |
+
+### Key v3 Changes
+
+1. **Umami Cloud uses API keys** instead of username/password (new auth path needed)
+2. **Revenue tracking** is a first-class feature (`revenue` + `currency` fields)
+3. **Tags** for A/B testing and event grouping
+4. **`data-before-send`** callback for payload interception
+5. **`data-exclude-search`** and **`data-exclude-hash`** for URL normalization
+6. **Realtime API** endpoint is new
+7. **`data-cache` is removed** in v3
+
+---
+
+## 3. Issue Triage & Priority
+
+### Priority Matrix
+
+| # | Issue | Type | Priority | Phase |
+|---|-------|------|----------|-------|
+| #39 | Comments don't show up in events | Bug | **P0 Critical** | 1 |
+| #28 | Site not sending stats | Bug | **P0 Critical** | 1 |
+| #52 | Which events are auto-tracked? | Docs/UX | **P1 High** | 1 |
+| #35 | Script URL for Umami Cloud unclear | Docs/UX | **P1 High** | 1 |
+| #53 | How to set data-tag? | Feature gap | **P1 High** | 2 |
+| #24 | Improve settings page | UX | **P1 High** | 2 |
+| #4 | Use Umami API for fetching info | Feature | **P2 Medium** | 3 |
+| #34 | WooCommerce revenue tracking | Feature | **P2 Medium** | 4 |
+| #36 | Add proxy mode | Feature | **P2 Medium** | 5 |
+| #5 | Add dashboard panel | Feature | **P3 Low** | 6 |
+
+### Issues NOT in Scope
+
+- #38 (closed — user error)
+- #23 (closed — tests exist now)
+
+---
+
+## 4. Implementation Phases
+
+```
+Phase 1: Foundation & Bug Fixes ──────────── Fixes #28, #39, #52, #35
+Phase 2: v3 Tracker Attributes ──────────── Fixes #53, #24 (partial)
+Phase 3: Umami API Integration ──────────── Fixes #4, #24 (complete)
+Phase 4: WooCommerce Revenue Tracking ───── Fixes #34
+Phase 5: Proxy Mode ─────────────────────── Fixes #36
+Phase 6: Dashboard Panel ────────────────── Fixes #5
+```
+
+Each phase is a separate PR. Each PR must pass existing Playwright tests + new tests for the phase.
+
+---
+
+## Phase 1: Foundation & Bug Fixes
+
+### 1.1 Fix: Comment Event Tracking (#39)
+
+**Root Cause Analysis:**
+
+The current implementation in `class-manager.php` (`filter_comment_form_submit_button`) has issues:
+
+1. It transforms `<button>` tags to `<input>` tags to inject attributes — fragile approach that breaks with custom themes and comment plugins (wpDiscuz, etc.)
+2. The regex replacement only matches specific button HTML patterns
+3. Third-party comment plugins (wpDiscuz, Jetpack Comments) use entirely different form structures
+
+**Fix:**
+
+```
+a) Replace the regex-based button attribute injection with a JavaScript-based approach
+b) Use wp_footer to inject a small JS snippet that attaches umami event attributes
+   to ANY comment submit button/form, regardless of theme or plugin
+c) Target the comment form by ID (#commentform) or class, with fallback selectors
+d) Support custom selectors via a filter hook for extensibility
+```
+
+**Implementation:**
+
+- In `class-manager.php`, replace `filter_comment_form_submit_button()` with a new
+  `render_comment_tracking_script()` method
+- The JS snippet finds the comment form submit button dynamically at DOM ready
+- Add a `wp_umami_comment_form_selector` filter for themes/plugins with non-standard forms
+- This approach works with native WP comments, wpDiscuz, and most comment plugins
+
+**Backwards compatibility:** The old filter on `comment_form_submit_button` is removed. Users relying on the PHP filter won't notice because it was silently broken for many themes anyway. The new JS approach works everywhere.
+
+### 1.2 Fix: Stats Not Sending (#28)
+
+**Root Cause Analysis:**
+
+Based on the issue reports, the problem occurs when:
+1. The plugin is enabled but the script doesn't render (edge case in conditional checks)
+2. WordPress version compatibility — `esc_attr_e()` is used where `esc_attr()` should be (outputs translated text, not raw attribute value)
+3. The script URL or website ID contains whitespace/newline characters from copy-paste
+
+**Fixes:**
+
+```
+a) Replace esc_attr_e() with esc_attr() for script attribute output (esc_attr_e echoes
+   translated text, which is wrong for data attributes)
+b) Trim whitespace from script_url and website_id on save AND on render
+c) Add a "Diagnostics" section to the settings page that:
+   - Shows whether the script tag would be rendered for the current user
+   - Shows the exact script tag that will be injected
+   - Warns if script_url or website_id look invalid
+d) Add wp_umami_should_track filter so developers can programmatically control tracking
+```
+
+### 1.3 UX: Auto-Tracking Clarification (#52)
+
+**Problem:** Users don't understand what "auto tracking" means.
+
+**Fix:**
+
+- Update the settings page description for the Auto Tracking toggle:
+  - Current: "Enable the automatic events and pageviews tracking."
+  - New: "Automatically track page views and link clicks. When disabled, you must
+    call `umami.track()` manually in your theme or plugin code. This controls the
+    Umami tracker's `data-auto-track` attribute."
+- Add a help link pointing to `https://umami.is/docs/tracker-functions`
+
+### 1.4 UX: Umami Cloud Script URL (#35)
+
+**Problem:** Umami Cloud users don't know their script URL.
+
+**Fix:**
+
+- Add helper text below the Script URL field:
+  - "For self-hosted Umami: typically `https://your-domain.com/script.js`"
+  - "For Umami Cloud: use `https://cloud.umami.is/script.js`"
+- Add a link to Umami's setup documentation
+
+### 1.5 Code Quality: Fix esc_attr_e Usage
+
+**Problem:** `esc_attr_e()` is for echoing translatable strings in attributes. The plugin uses it to output raw values like URLs and UUIDs, which should use `esc_attr()` instead.
+
+**Fix:** Audit all uses of `esc_attr_e()` in `class-manager.php` and replace with `echo esc_attr()` where the value is not a translatable string.
+
+### 1.6 Deprecate `data-cache` Option
+
+**Problem:** The `data-cache` attribute was removed in later Umami v2 and does not exist in v3.
+
+**Fix:**
+
+- Keep the option in storage for now (don't break existing installs)
+- Hide it from the settings UI by default
+- Add a `wp_umami_show_deprecated_options` filter (defaults to `false`) for users who still need it
+- If the option is enabled but hidden, still render the attribute (v2 compat)
+- Add an admin notice if `data-cache` is enabled: "The cache option is deprecated and will be removed in a future version."
+
+---
+
+## Phase 2: v3 Tracker Attributes
+
+### 2.1 Add `data-tag` Support (#53)
+
+**Implementation:**
+
+- New option: `tag` (string, default: empty)
+- Settings field: text input, "Tag — Assign a tag to group events. Useful for A/B testing."
+- Help link: `https://umami.is/docs/tags`
+- In `render_script()`: if `tag` is non-empty, add `data-tag="..."` attribute
+
+### 2.2 Add `data-domains` Support
+
+**Implementation:**
+
+- New option: `domains` (string, default: empty)
+- Settings field: text input, "Domains — Comma-separated list of domains where tracking is active. Leave empty to track on all domains."
+- Help link: `https://umami.is/docs/tracker-configuration`
+- In `render_script()`: if `domains` is non-empty, add `data-domains="..."` attribute
+
+### 2.3 Add `data-exclude-search` Support (v3 only)
+
+**Implementation:**
+
+- New option: `exclude_search` (int, default: 0)
+- Settings field: checkbox, "Exclude URL search parameters from tracked page URLs."
+- In `render_script()`: if enabled, add `data-exclude-search="true"`
+- **v2 compat:** attribute is ignored by v2 tracker script (no harm)
+
+### 2.4 Add `data-exclude-hash` Support (v3 only)
+
+**Implementation:**
+
+- New option: `exclude_hash` (int, default: 0)
+- Settings field: checkbox, "Exclude URL hash values from tracked page URLs."
+- In `render_script()`: if enabled, add `data-exclude-hash="true"`
+- **v2 compat:** attribute is ignored by v2 tracker script (no harm)
+
+### 2.5 Add `data-before-send` Support (v3 only, advanced)
+
+**Implementation:**
+
+- New option: `before_send` (string, default: empty)
+- Settings field: text input in Advanced section, "Before Send Function — Name of a JavaScript function to intercept tracking data before it's sent. The function receives `(type, payload)` and should return the payload to send, or a falsy value to cancel."
+- In `render_script()`: if non-empty, add `data-before-send="..."` attribute
+- Sanitize with `sanitize_text_field()` — only allow valid JS function names (`[a-zA-Z_$][a-zA-Z0-9_$.]*`)
+- **v2 compat:** attribute is ignored by v2 tracker script
+
+### 2.6 Settings Page Overhaul (#24, partial)
+
+**Restructure the settings page into clear sections:**
+
+```
+┌─────────────────────────────────────────────────┐
+│ Integrate Umami Settings                        │
+├─────────────────────────────────────────────────┤
+│ CONNECTION                                      │
+│  [✓] Enable tracking                            │
+│  Script URL: [________________________]         │
+│  Website ID: [________________________]         │
+│  Host URL:   [________________________]         │
+│  [_] Use Host URL as data endpoint              │
+├─────────────────────────────────────────────────┤
+│ TRACKING BEHAVIOR                               │
+│  [✓] Auto tracking (page views & clicks)        │
+│  [_] Respect Do Not Track browser setting       │
+│  [_] Track comment form submissions             │
+│  Tag: [________________________]                │
+│  Domains: [________________________]            │
+├─────────────────────────────────────────────────┤
+│ URL HANDLING (v3+)                              │
+│  [_] Exclude search params from URLs            │
+│  [_] Exclude hash values from URLs              │
+├─────────────────────────────────────────────────┤
+│ PRIVACY & ADMIN                                 │
+│  [✓] Ignore admin users                         │
+├─────────────────────────────────────────────────┤
+│ ADVANCED                                        │
+│  Before Send function: [________________]       │
+├─────────────────────────────────────────────────┤
+│ DIAGNOSTICS                                     │
+│  Status: ✓ Tracking active                      │
+│  Script tag preview: <script async defer...>    │
+│  Umami version detected: v3                     │
+└─────────────────────────────────────────────────┘
+```
+
+---
+
+## Phase 3: Umami API Integration
+
+### 3.1 API Client Class (#4)
+
+**New file: `inc/class-api-client.php`**
+
+A server-side HTTP client for the Umami API using `wp_remote_get()` / `wp_remote_post()`.
+
+**Features:**
+
+- Authenticate with username/password (v2 + v3 self-hosted) or API key (v3 Cloud)
+- Token caching in WordPress transients (tokens expire, store with TTL)
+- Version detection: call `/api/auth/verify` and inspect response to determine v2 vs v3
+- Methods:
+  - `authenticate()` — get/refresh bearer token
+  - `get_websites()` — list websites for auto-selection of website ID
+  - `get_website_stats($website_id, $start, $end)` — fetch summary stats
+  - `get_active_visitors($website_id)` — real-time visitor count
+  - `detect_version()` — heuristic to determine Umami v2 vs v3
+
+**v2/v3 Compatibility:**
+
+```php
+// Version detection heuristic:
+// 1. Try GET /api/realtime/:id — only exists in v3
+// 2. If 404 → v2, if 200 → v3
+// 3. Cache detected version in transient for 24 hours
+```
+
+### 3.2 New Settings: API Credentials
+
+**New options:**
+
+| Option | Type | Default | Purpose |
+|--------|------|---------|---------|
+| `api_enabled` | int | 0 | Enable API features |
+| `api_auth_type` | string | 'credentials' | 'credentials' or 'api_key' |
+| `api_username` | string | '' | Umami username (self-hosted) |
+| `api_password` | string | '' | Umami password (encrypted with `wp_encrypt()` or similar) |
+| `api_key` | string | '' | API key (Umami Cloud) |
+
+**Settings UI:**
+
+- New "API Connection" section in settings
+- Radio: Self-hosted (username/password) or Cloud (API key)
+- "Test Connection" button (AJAX call that runs `authenticate()` + `get_websites()`)
+- If connection succeeds, show dropdown of websites for auto-populating website ID
+
+### 3.3 Auto-Populate Website ID
+
+Once API credentials are provided and a connection is tested:
+
+- Fetch list of websites via `get_websites()`
+- Show a dropdown to select the website
+- Auto-fill the Website ID field
+- Store the selected website name for display
+
+---
+
+## Phase 4: WooCommerce Revenue Tracking
+
+### 4.1 WooCommerce Integration (#34)
+
+**New file: `inc/class-woocommerce.php`**
+
+**Conditional loading:** Only loaded if WooCommerce is active (`class_exists('WooCommerce')`).
+
+**Events to Track:**
+
+| Event | Trigger | Data |
+|-------|---------|------|
+| `product-view` | Single product page | `product_name`, `product_id`, `product_category`, `product_price`, `currency` |
+| `add-to-cart` | Add to cart button click | `product_name`, `product_id`, `quantity`, `revenue`, `currency` |
+| `checkout-start` | Checkout page load | `cart_total`, `item_count`, `currency` |
+| `purchase` | Order thank-you page | `order_id`, `revenue`, `currency`, `item_count` |
+
+**Implementation approach:**
+
+```
+a) Product view: Hook into woocommerce_after_single_product to inject
+   umami.track() call with product data
+
+b) Add to cart: Hook into woocommerce_add_to_cart or use data-umami-event
+   attributes on the add-to-cart button
+
+c) Checkout start: Hook into woocommerce_before_checkout_form
+
+d) Purchase complete: Hook into woocommerce_thankyou to inject
+   umami.track('purchase', { revenue: total, currency: 'USD' })
+```
+
+**Revenue tracking format (Umami v3):**
+
+```javascript
+umami.track('purchase', {
+  revenue: 49.99,
+  currency: 'USD'
+});
+```
+
+**v2 compat:** Revenue fields are ignored by v2 Umami — events still tracked, just without revenue attribution. No harm.
+
+### 4.2 WooCommerce Settings
+
+New settings section (only visible when WooCommerce is active):
+
+- `[✓] Enable WooCommerce tracking`
+- `[✓] Track product views`
+- `[✓] Track add-to-cart`
+- `[✓] Track checkout`
+- `[✓] Track purchases (with revenue)`
+
+---
+
+## Phase 5: Proxy Mode
+
+### 5.1 Proxy Implementation (#36)
+
+**New file: `inc/class-proxy.php`**
+
+**Problem:** Ad blockers block requests to known Umami domains and `/script.js` / `/api/send` paths.
+
+**Solution:** Proxy these two resources through WordPress:
+
+1. **Script proxy:** Register a WordPress rewrite rule that serves the Umami tracker script from a custom local path
+2. **Data proxy:** Register a WordPress REST API endpoint that forwards tracking data to the Umami `/api/send` endpoint
+
+**Implementation:**
+
+```
+a) Add rewrite rule: /wp-umami-script.js → proxied from Umami script URL
+   (configurable path via option or filter)
+
+b) Register REST endpoint: /wp-json/wp-umami/v1/collect
+   → Forwards POST body to Umami /api/send
+   → Passes through User-Agent header (required by Umami)
+   → Returns Umami response
+
+c) When proxy mode is enabled, render_script() uses the local proxy
+   URL instead of the remote Umami script URL, and sets
+   data-host-url to the WordPress site URL
+
+d) Cache the proxied script.js in a transient (1 hour TTL)
+   to avoid hitting Umami on every page load
+```
+
+### 5.2 Proxy Settings
+
+- `[_] Enable proxy mode`
+- Custom script path: `[wp-umami-script.js]` (default, configurable)
+- Help text explaining why this is useful (ad blockers)
+- Warning: "Proxy mode increases WordPress server load slightly"
+
+---
+
+## Phase 6: Dashboard Panel
+
+### 6.1 Analytics Dashboard (#5)
+
+**Depends on:** Phase 3 (API client)
+
+**Two approaches (implement both, user chooses):**
+
+#### Option A: iframe Share URL
+
+- If the Umami website has a share URL configured, embed it in an iframe
+- Simplest approach, works without API credentials
+- Settings: "Share URL" text field
+
+#### Option B: Native Widget with API Data
+
+- Use the API client to fetch stats and render them natively
+- Display: visitors, page views, bounce rate, top pages, top referrers
+- Time range selector (today, 7d, 30d)
+- Active visitors count (real-time)
+- Update via AJAX on the dashboard
+
+**Implementation:**
+
+- Enhance `class-dashboard-widget.php` to support both modes
+- Register a full admin page under Tools → Umami Analytics for the detailed view
+- Dashboard widget shows summary stats with link to full page
+
+---
+
+## 7. Testing Strategy
+
+### Existing Tests (Playwright E2E)
+
+- `basic.test.js` — Plugin activation, menu registration
+- `settings.test.js` — Enable/disable tracking, settings migration
+
+### New Tests Per Phase
+
+#### Phase 1 Tests
+
+```
+- test: comment tracking renders JS snippet (not PHP button mutation)
+- test: comment tracking JS attaches to #commentform
+- test: script tag uses esc_attr() not esc_attr_e()
+- test: whitespace in script_url is trimmed
+- test: diagnostics section renders in settings
+- test: Umami Cloud helper text appears
+```
+
+#### Phase 2 Tests
+
+```
+- test: data-tag attribute renders when tag is set
+- test: data-tag is absent when tag is empty
+- test: data-domains attribute renders with comma-separated values
+- test: data-exclude-search renders when enabled
+- test: data-exclude-hash renders when enabled
+- test: data-before-send renders with function name
+- test: data-before-send rejects invalid function names
+- test: data-cache is hidden from settings by default
+- test: settings page sections render in correct order
+```
+
+#### Phase 3 Tests
+
+```
+- test: API client authenticates with username/password
+- test: API client authenticates with API key
+- test: API client caches token in transient
+- test: get_websites() returns website list
+- test: detect_version() correctly identifies v2 vs v3
+- test: Test Connection AJAX endpoint works
+- test: website dropdown populates after connection test
+```
+
+#### Phase 4 Tests
+
+```
+- test: WooCommerce section hidden when WC not active
+- test: WooCommerce section visible when WC active
+- test: product-view event fires on single product page
+- test: purchase event includes revenue and currency
+- test: revenue data format matches Umami spec
+```
+
+#### Phase 5 Tests
+
+```
+- test: proxy rewrite rule registered when proxy enabled
+- test: proxy script endpoint returns Umami script content
+- test: proxy collect endpoint forwards to Umami /api/send
+- test: render_script uses proxy URL when proxy enabled
+- test: User-Agent header forwarded through proxy
+```
+
+#### Phase 6 Tests
+
+```
+- test: dashboard widget renders share URL iframe
+- test: dashboard widget renders native stats
+- test: AJAX endpoint returns stats data
+- test: active visitors displayed
+```
+
+### Unit Tests (New — PHP)
+
+Add PHPUnit with `@wordpress/env` or `wp-phpunit`:
+
+```
+- Options::get_options() returns defaults for new install
+- Options::maybe_migrate_options() migrates old options
+- Manager::render_script() output contains correct attributes
+- Settings::validate_options() sanitizes all inputs
+- ApiClient::authenticate() handles success/failure
+- ApiClient::detect_version() returns 'v2' or 'v3'
+- WooCommerce class only loads when WC is active
+- Proxy class registers rewrite rules
+```
+
+---
+
+## 8. Backwards Compatibility Contract
+
+### Guaranteed
+
+| What | Guarantee |
+|------|-----------|
+| Existing options | All current options remain functional. No existing option is removed or renamed. |
+| Option name | `integrate_umami_options` key unchanged |
+| Migration | Old `umami_options` migration still works |
+| PHP version | 7.4+ maintained |
+| WordPress version | 6.0+ maintained |
+| v2 tracker compat | All new `data-*` attributes are silently ignored by v2 tracker scripts |
+| Script injection | `wp_footer` hook location unchanged |
+| Admin ignore | `manage_options` capability check unchanged |
+
+### Deprecated (with notice)
+
+| What | Timeline |
+|------|----------|
+| `data-cache` option | Hidden in UI now, removed in v1.0 |
+| `data-do-not-track` label | Clarify it works in both v2 and v3 (remove "deprecated" text) |
+
+### Breaking Changes (none planned)
+
+The comment tracking approach changes from PHP button mutation to JS injection, but the old approach was already broken for many themes, so this is a net improvement with no visible regression.
+
+---
+
+## 9. File-by-File Change Map
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `wp-umami.php` | Bump version, conditionally load new classes |
+| `inc/class-manager.php` | Fix `esc_attr_e`, add new data attributes, replace comment tracking with JS approach, add `wp_umami_should_track` filter |
+| `inc/class-options.php` | Add new option defaults (tag, domains, exclude_search, exclude_hash, before_send, api_*, woocommerce_*), deprecate cache |
+| `inc/class-settings.php` | Restructured settings page sections, new API/WooCommerce/Proxy settings, diagnostics panel, validation for new options |
+| `inc/class-dashboard-widget.php` | Support iframe + native API stats modes |
+| `inc/templates/settings-page.php` | Complete overhaul — sectioned layout, better help text, Cloud guidance, diagnostics |
+| `css/integrate-umami.css` | Updated styles for new settings layout |
+| `readme.txt` | Updated description, changelog, FAQ |
+| `readme.md` | Sync with readme.txt |
+| `composer.json` | Add PHPUnit dev dependency |
+| `package.json` | Update test scripts |
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `inc/class-api-client.php` | Umami HTTP API client (Phase 3) |
+| `inc/class-woocommerce.php` | WooCommerce integration (Phase 4) |
+| `inc/class-proxy.php` | Ad-blocker proxy mode (Phase 5) |
+| `tests/phpunit/` | PHPUnit test directory |
+| `tests/phpunit/test-options.php` | Options unit tests |
+| `tests/phpunit/test-manager.php` | Manager unit tests |
+| `tests/phpunit/test-api-client.php` | API client unit tests |
+| `tests/e2e/comment-tracking.test.js` | Comment tracking E2E |
+| `tests/e2e/tracker-attributes.test.js` | v3 attributes E2E |
+
+---
+
+## 10. Risk Register
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Umami v3 API changes during development | Medium | Pin to documented v3 API, version detection allows adaptation |
+| WooCommerce version incompatibility | Medium | Test against WC 8.x+, use only stable hooks |
+| Proxy mode performance impact | Low | Cache script in transient, document tradeoff |
+| API credentials stored insecurely | High | Use WordPress `wp_encrypt()`/encryption, never log credentials |
+| Breaking existing installs on update | High | Options migration with defaults, feature flags for new features |
+| Ad-blocker arms race | Low | Configurable proxy paths, document limitation |
+| Theme incompatibility with comment tracking | Medium | JS approach with configurable selectors + filter hook |
+
+---
+
+## Recommended PR Sequence
+
+```
+PR #1  Phase 1 — Bug fixes, esc_attr, comment tracking, diagnostics, docs
+PR #2  Phase 2 — v3 tracker attributes, settings page restructure
+PR #3  Phase 3 — API client, credentials, auto-populate website ID
+PR #4  Phase 4 — WooCommerce revenue tracking
+PR #5  Phase 5 — Proxy mode
+PR #6  Phase 6 — Dashboard analytics panel
+```
+
+Each PR should be independently reviewable and releasable. Phases 4-6 are feature additions that don't affect core tracking functionality.
+
+---
+
+## 11. Quality of Life Improvements (Research-Driven)
+
+These are additional improvements discovered through deep research into WordPress best practices,
+PHP compatibility, Umami v3 migration realities, and competitor analysis.
+
+### 11.1 PHP Compatibility Hardening
+
+**Current state:** Plugin requires PHP 7.4+. No dynamic property declarations. No PHP 8.x testing.
+
+**Issues found:**
+
+| PHP Version | Issue | Status |
+|-------------|-------|--------|
+| PHP 8.2+ | Dynamic property creation deprecated — all class properties must be explicitly declared | **Audit needed** |
+| PHP 8.1+ | Passing `null` to non-nullable internal function params (e.g., `trim()`, `str_replace()`) triggers deprecation notices | **Audit needed** |
+| PHP 8.0+ | Named arguments can break if param names change between versions | Low risk |
+| PHP 8.3+ | Various additional signature changes | Low risk |
+| PHP 8.4+ | WordPress 6.7+ has beta support | Test needed |
+
+**Actions:**
+
+- Audit all classes for undeclared properties (PHP 8.2 dynamic properties deprecation)
+- Add null-safety guards: wrap all `trim()`, `esc_url()`, etc. calls with null coalescing (`?? ''`)
+- Add PHPCompatibility PHPCS sniffs to CI (already in `composer.json` dev deps)
+- Test against PHP 7.4, 8.0, 8.1, 8.2, 8.3 in CI matrix
+- Update `composer.json` to declare `"php": ">=7.4"` explicitly in `require`
+
+### 11.2 WordPress Version Compatibility
+
+**Critical changes in recent WordPress versions:**
+
+| WP Version | Change | Impact on Plugin |
+|------------|--------|-----------------|
+| 6.7 | Translations must load at `init` or later (not `plugins_loaded`) | **Must fix** — current plugin loads at `plugins_loaded` |
+| 6.7 | PHP 7.0/7.1 support dropped | No impact (plugin already requires 7.4) |
+| 6.8 | Speculative loading (prefetch URLs) | No impact |
+| 6.9 | `WP_Dependencies->add_data()` deprecated | No impact (not used) |
+| 6.7+ | Stricter JS handling | Test script injection |
+
+**Actions:**
+
+- Move text domain loading from `plugins_loaded` to `init` hook
+- Test with WordPress 6.5, 6.6, 6.7, 6.8, 6.9 in CI matrix
+- Update `readme.txt` tested-up-to from 6.6 to latest stable
+- Add `Requires at least: 6.0` header validation
+
+### 11.3 Internationalization (i18n) Fixes
+
+**Issues found in current code:**
+
+1. Text domain `integrate-umami` matches the plugin slug (correct)
+2. But `esc_attr_e()` is used on non-translatable values (URLs, UUIDs) — produces broken output
+3. Several strings in `settings-page.php` are hardcoded English without `__()` wrapper
+4. No `.pot` file or translation workflow
+
+**Actions:**
+
+- Audit all user-facing strings in templates and ensure `__()` / `_e()` wrapping with `'integrate-umami'` domain
+- Generate `.pot` file using `wp i18n make-pot`
+- Store in `languages/` directory
+- Keep text domain as string literal (never a variable — required by extraction tools)
+
+### 11.4 Umami v3 Critical Migration Notes
+
+**MySQL support dropped in v3** — this is the biggest breaking change. The plugin should warn users.
+
+**Actions:**
+
+- Add version detection (Phase 3) that identifies v2 vs v3
+- If Umami instance responds with v3 signatures but plugin detects MySQL-related errors, show admin notice
+- Add a "Compatibility Notes" section to settings page:
+  - "Umami v3 requires PostgreSQL. MySQL is no longer supported."
+  - "If upgrading from v2, back up your database first."
+- Document in `readme.txt` FAQ
+
+### 11.5 API Client: Cloud vs Self-Hosted Auth
+
+**Research finding:** Umami Cloud uses `x-umami-api-key` header (NOT Bearer token).
+
+**Updated API Client design:**
+
+```
+Auth flow:
+1. User selects: "Self-Hosted" or "Umami Cloud"
+2. Self-Hosted → username/password → POST /api/auth/login → Bearer token
+3. Cloud → API key → x-umami-api-key header on all requests
+4. Cloud base URL: https://api.umami.is/v1 (NOT https://cloud.umami.is/api)
+5. Rate limit: 50 calls per 15 seconds (Cloud)
+6. Restricted routes: /me/password, /users, /users/* (cannot use API keys)
+```
+
+**Actions:**
+
+- Support both auth methods in `class-api-client.php`
+- Cache self-hosted tokens in transient with TTL
+- Implement rate limiting awareness for Cloud (respect 429 responses)
+- Show appropriate credential fields based on deployment type selection
+
+### 11.6 Competitor Feature Parity Analysis
+
+**`umami-wp-connect` (by ceviixx)** is listed as an official Umami integration and has:
+
+| Feature | umami-wp-connect | wp-umami (current) | wp-umami (planned) |
+|---------|-----------------|--------------------|--------------------|
+| Basic tracking | Yes | Yes | Yes |
+| Form tracking (CF7, WPForms) | Yes (auto-detect) | No | Phase 4+ |
+| Gutenberg integration | Yes | No | Not planned |
+| beforeSend support | Yes | No | Phase 2 |
+| Clean URL params | Yes | No | Phase 2 |
+| Event management hub | Yes | No | Phase 3 |
+| Dashboard widget | Yes | Yes | Phase 6 (enhanced) |
+| WooCommerce revenue | Unknown | No | Phase 4 |
+| Proxy mode | No | No | Phase 5 |
+| WordPress.org listing | No | Yes | Yes |
+
+**Competitive advantages we should maintain/build:**
+
+1. **WordPress.org listing** — this is a major distribution advantage
+2. **Proxy mode** — neither competitor has this
+3. **WooCommerce revenue tracking** — Conversion Bridge charges $79/yr for this
+4. **API-powered dashboard** — native stats without iframe
+5. **v2/v3 dual compatibility** — ceviixx targets v3 only
+
+### 11.7 Settings Page UX: Beginner vs Advanced
+
+**WordPress best practice:** "Decisions, not options" — expose advanced config via filters, not UI fields.
+
+**Redesigned settings page with progressive disclosure:**
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ Integrate Umami — Settings                                         │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│ ── GETTING STARTED ──────────────────────────────────────────────── │
+│                                                                     │
+│  [✓] Enable tracking                                                │
+│                                                                     │
+│  Deployment type:  (●) Self-hosted  ( ) Umami Cloud                 │
+│                                                                     │
+│  Script URL: [https://stats.example.com/script.js________]          │
+│  ℹ Self-hosted: https://your-domain.com/script.js                   │
+│  ℹ Umami Cloud: https://cloud.umami.is/script.js                    │
+│                                                                     │
+│  Website ID: [xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx____]             │
+│  ℹ Found in your Umami dashboard → Settings → Websites              │
+│                                                                     │
+│  [ Save Settings ]                                                  │
+│                                                                     │
+│ ── TRACKING OPTIONS ─────────────────────────────────────────────── │
+│                                                                     │
+│  [✓] Auto tracking — Automatically track page views and clicks      │
+│      When disabled, call umami.track() manually. Learn more ↗       │
+│                                                                     │
+│  [_] Track comment submissions — Log comment form submits as events  │
+│                                                                     │
+│  [✓] Ignore admin users — Don't track logged-in administrators      │
+│                                                                     │
+│  [_] Respect Do Not Track — Honor browser DNT setting               │
+│                                                                     │
+│ ── ADVANCED OPTIONS ──────────────── [▼ Expand] ─────────────────── │
+│                                                                     │
+│  Host URL: [________________________]                               │
+│  ℹ Override where tracking data is sent. Leave empty to use the      │
+│    same server as your script URL.                                   │
+│                                                                     │
+│  Tag: [________________________]                                    │
+│  ℹ Group all events from this site under a tag. Useful for           │
+│    A/B testing. Learn more ↗                                         │
+│                                                                     │
+│  Allowed Domains: [________________________]                        │
+│  ℹ Comma-separated. Only track on these domains. Leave empty for all.│
+│                                                                     │
+│  [_] Exclude search params from URLs                                │
+│  [_] Exclude hash values from URLs                                  │
+│      ℹ These options require Umami v3+                               │
+│                                                                     │
+│  Before Send function: [________________________]                   │
+│  ℹ Name of a JS function to intercept/modify data before sending.    │
+│    Requires Umami v3+. Learn more ↗                                  │
+│                                                                     │
+│  [_] Enable proxy mode — Serve tracking script through WordPress     │
+│      ℹ Helps bypass ad blockers. Increases server load slightly.     │
+│      Proxy script path: [wp-umami-t.js]                              │
+│                                                                     │
+│ ── API CONNECTION ───────────────── [▼ Expand] ──────────────────── │
+│                                                                     │
+│  [_] Enable API features (dashboard stats, auto-setup)              │
+│                                                                     │
+│  Auth type:  (●) Username/Password  ( ) API Key                     │
+│                                                                     │
+│  Username: [________]   Password: [••••••••]                        │
+│      — or —                                                         │
+│  API Key: [________________________________________]                │
+│                                                                     │
+│  [ Test Connection ]  ✓ Connected — Umami v3 detected               │
+│                                                                     │
+│ ── WOOCOMMERCE ──────────────────── (requires WooCommerce) ──────── │
+│                                                                     │
+│  [_] Enable WooCommerce tracking                                    │
+│  [✓] Track product views                                            │
+│  [✓] Track add-to-cart                                              │
+│  [✓] Track checkout                                                 │
+│  [✓] Track purchases (with revenue)                                 │
+│                                                                     │
+│ ── DIAGNOSTICS ──────────────────────────────────────────────────── │
+│                                                                     │
+│  Tracking status: ✓ Active                                          │
+│  Umami version: v3 (detected)                                       │
+│  Script tag preview:                                                │
+│  <script async defer src="https://stats.example.com/script.js"      │
+│    data-website-id="xxx" data-auto-track="true"></script>            │
+│                                                                     │
+│  PHP version: 8.2.1 ✓                                               │
+│  WordPress version: 6.8 ✓                                           │
+│  Plugin version: 1.0.0                                              │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Key UX principles applied:**
+
+1. **Beginner path:** Top section ("Getting Started") has only 3 fields — enable, script URL, website ID. That's all most users need.
+2. **Progressive disclosure:** Advanced Options, API Connection, and WooCommerce are collapsed by default.
+3. **Inline help:** Every field has contextual `ℹ` descriptions, not a separate docs page.
+4. **Deployment type selector:** Self-hosted vs Cloud changes the helper text and which fields are shown.
+5. **Diagnostics always visible:** Users can immediately see if tracking is working without leaving the page.
+6. **WooCommerce section conditional:** Only rendered when WooCommerce is active.
+
+### 11.8 WordPress Plugin Best Practices Checklist
+
+Applied throughout all phases:
+
+| Practice | Status | Notes |
+|----------|--------|-------|
+| **Nonces on all forms** | ✅ Already done | `settings_fields('integrate_umami')` |
+| **Capability checks** | ✅ Already done | `manage_options` |
+| **Input sanitization** | ⚠️ Needs audit | Some fields use `esc_url_raw`, others need tighter validation |
+| **Output escaping** | ❌ Bug found | `esc_attr_e()` misuse in `class-manager.php` |
+| **Yoda conditions** | ⚠️ Inconsistent | WPCS standard, enforce via PHPCS |
+| **Text domain consistency** | ⚠️ Needs audit | Some strings may be unwrapped |
+| **Conditional asset loading** | ✅ Already done | CSS only on settings page |
+| **Uninstall cleanup** | ⚠️ Incomplete | Options deleted on deactivation, but should use `uninstall.php` instead |
+| **Prefix all functions/classes** | ✅ Done | Namespace `Ancozockt\Umami` |
+| **$wpdb->prepare()** | N/A | No custom queries currently |
+| **Transient caching** | ❌ Missing | Needed for API client (Phase 3) |
+| **register_uninstall_hook** | ❌ Missing | Should replace deactivation cleanup |
+
+**Actions:**
+
+- Move option cleanup from `register_deactivation_hook` to `register_uninstall_hook` (or `uninstall.php`)
+  - Deactivation = temporary disable (should NOT delete data)
+  - Uninstall = permanent removal (SHOULD delete data)
+  - This is a common plugin mistake — users lose settings when deactivating temporarily
+- Add PHPCS to CI with WordPress coding standards
+- Add PHPCompatibility sniffs for PHP 7.4-8.4 range
+
+### 11.9 Security Hardening
+
+| Area | Current | Improvement |
+|------|---------|-------------|
+| API credentials | Not stored | Use `sodium_crypto_secretbox` (PHP 7.2+) or `openssl_encrypt` for password/API key storage |
+| AJAX endpoints | None | Add nonce verification + `manage_options` capability check to all new AJAX handlers |
+| Proxy endpoint | N/A | Rate-limit proxy endpoint to prevent abuse; validate request origin |
+| Options validation | Basic | Add regex validation for website ID (UUID format), script URL (must end in .js), function names (JS identifier pattern) |
+| XSS prevention | Mostly done | Audit all `echo` statements for proper escaping |
+
+### 11.10 Performance Considerations
+
+| Area | Approach |
+|------|----------|
+| Script injection | Already minimal — single `<script>` tag in footer |
+| API calls | Cache all API responses in transients (stats: 5 min, websites: 1 hour, version: 24 hours) |
+| Proxy mode | Cache proxied script.js in transient (1 hour), serve from cache |
+| Dashboard widget | Fetch stats via AJAX (lazy load), don't block dashboard render |
+| Options loading | Single `get_option()` call, already efficient |
+| Admin assets | Only load CSS/JS on plugin settings page (`admin_enqueue_scripts` with page check) |
+
+### 11.11 Multisite Compatibility
+
+**Issue #29 (closed)** asked about multisite support. Current state: untested.
+
+**Actions:**
+
+- Test plugin activation on multisite (network activate vs per-site)
+- Options are per-site by default (`get_option` is site-scoped in multisite) — this is correct behavior since each site may have a different Umami website ID
+- Add `is_multisite()` check and documentation note
+- Consider network-wide settings for shared script URL / host URL with per-site website IDs
+
+---
+
+## 12. Updated Risk Register
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| **Umami v3 dropped MySQL** | High for MySQL users | Admin notice + documentation. Plugin itself is unaffected (no DB dependency). |
+| **v3 API: `type=url` → `type=path`** | Medium for API client | Use `type=path` for v3, `type=url` for v2. Version detection guides parameter selection. |
+| **PHP 8.2 dynamic properties** | Medium | Audit all classes, declare all properties explicitly. |
+| **PHP 8.1 null parameter warnings** | Medium | Add null coalescing operators (`?? ''`) to all internal function calls. |
+| **WP 6.7 translation loading change** | Low | Move text domain load to `init` action. |
+| **Umami Cloud rate limits (50/15s)** | Low | Cache API responses aggressively, show rate limit warning in UI. |
+| **Competitor leapfrogging** | Medium | Focus on unique advantages: WP.org listing, proxy mode, WooCommerce, dual v2/v3. |
+| **Deactivation deletes data** | High | Move cleanup to `uninstall.php`, NOT deactivation hook. Critical fix. |
+
+---
+
+## 13. CI/CD Pipeline (New)
+
+### GitHub Actions Workflow
+
+```yaml
+# .github/workflows/test.yml
+name: Tests
+on: [push, pull_request]
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - run: composer install
+      - run: composer php:lint
+
+  phpunit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        wp: ['6.5', '6.7', 'latest']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+      - run: composer install
+      - run: vendor/bin/phpunit
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx playwright install chromium --with-deps
+      - run: npm run start
+      - run: npm test
+
+  phpcompat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - run: composer install
+      - run: vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- .
+```
+
+---
+
+## 14. Development Environment
+
+### Local Setup
+
+```bash
+# Clone and install
+git clone https://github.com/Ancocodet/wp-umami.git
+cd wp-umami
+npm install
+composer install
+
+# Start WordPress (requires Docker)
+npm run start
+# → WordPress: http://localhost:8888 (admin/password)
+# → Plugin auto-activated
+
+# Run existing E2E tests
+npm test
+
+# Run PHP linting
+composer php:lint
+
+# Run PHPUnit (after setup in Phase 1)
+npx wp-env run tests-cli vendor/bin/phpunit
+```
+
+### Test Umami Instance
+
+- **URL:** https://stats.wavedepth.com
+- **Dashboard:** https://stats.wavedepth.com/websites
+- **Used for:** Integration testing of API client (Phase 3), dashboard widget (Phase 6)
+
+---
+
+## 15. Versioning Strategy
+
+| Release | Contents | Semver |
+|---------|----------|--------|
+| 0.9.0 | Phase 1 — Bug fixes, foundation | Minor (backwards compatible fixes) |
+| 0.10.0 | Phase 2 — v3 tracker attributes + settings overhaul | Minor (new features, no breaking) |
+| 1.0.0 | Phase 3 — API integration (major feature milestone) | Major (stable API surface) |
+| 1.1.0 | Phase 4 — WooCommerce revenue | Minor (new feature) |
+| 1.2.0 | Phase 5 — Proxy mode | Minor (new feature) |
+| 1.3.0 | Phase 6 — Dashboard panel | Minor (new feature) |

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,10 @@
         "squizlabs/php_codesniffer": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "wp-coding-standards/wpcs": "*",
-        "phpcompatibility/php-compatibility": "*"
+        "phpcompatibility/php-compatibility": "*",
+        "phpunit/phpunit": "^9.6",
+        "yoast/phpunit-polyfills": "^2.0",
+        "10up/wp_mock": "^1.0"
     },
     "autoload": {
         "classmap": [
@@ -36,6 +39,8 @@
             "@install-codestandards"
         ],
         "php:lint": "./vendor/bin/phpcs . -s",
-        "php:lint-fix": "./vendor/bin/phpcbf ."
+        "php:lint-fix": "./vendor/bin/phpcbf .",
+        "test": "./vendor/bin/phpunit",
+        "test:unit": "./vendor/bin/phpunit --testsuite unit"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,136 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "828fbc8624ea7525fcff4212dc081e75",
+    "content-hash": "bbc8ba4ccbbb9071b882f857690ac1ee",
     "packages": [],
     "packages-dev": [
         {
-            "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.0.0",
+            "name": "10up/wp_mock",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+                "url": "https://github.com/10up/wp_mock.git",
+                "reference": "f25b5895ed31bf5e7036fe0c666664364ae011c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "url": "https://api.github.com/repos/10up/wp_mock/zipball/f25b5895ed31bf5e7036fe0c666664364ae011c2",
+                "reference": "f25b5895ed31bf5e7036fe0c666664364ae011c2",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+                "antecedent/patchwork": "^2.1",
+                "mockery/mockery": "^1.6",
+                "php": ">=7.4 < 9",
+                "phpunit/phpunit": "^9.6"
             },
             "require-dev": {
-                "composer/composer": "*",
+                "behat/behat": "^v3.11.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "friendsofphp/php-cs-fixer": "^3.4",
+                "php-coveralls/php-coveralls": "^v2.7",
+                "php-stubs/wordpress-globals": "^0.2",
+                "php-stubs/wordpress-stubs": "^6.3",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "sebastian/comparator": "^4.0.8",
+                "sempro/phpunit-pretty-print": "^1.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WP_Mock\\": "./php/WP_Mock"
+                },
+                "classmap": [
+                    "php/WP_Mock.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A mocking library to take the pain out of unit testing for WordPress",
+            "support": {
+                "issues": "https://github.com/10up/wp_mock/issues",
+                "source": "https://github.com/10up/wp_mock/tree/1.1.0"
+            },
+            "time": "2025-03-12T00:36:13+00:00"
+        },
+        {
+            "name": "antecedent/patchwork",
+            "version": "2.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "https://antecedent.github.io/patchwork/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.3"
+            },
+            "time": "2025-09-17T09:00:56+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
                 "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
@@ -50,9 +152,9 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
@@ -60,7 +162,6 @@
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -81,9 +182,467 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2023-01-05T11:28:13+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-11T04:32:07+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T06:47:08+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -149,29 +708,29 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.2.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
+                "reference": "b598aa890815b8df16363271b659d73280129101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
-                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
+                "reference": "b598aa890815b8df16363271b659d73280129101",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.9",
-                "squizlabs/php_codesniffer": "^3.8.0"
+                "phpcsstandards/phpcsutils": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -221,35 +780,39 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2023-12-08T16:49:07+00:00"
+            "time": "2025-11-12T23:06:57+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.12",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
-                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -286,6 +849,7 @@
                 "phpcodesniffer-standard",
                 "phpcs",
                 "phpcs3",
+                "phpcs4",
                 "standards",
                 "static analysis",
                 "tokens",
@@ -309,22 +873,1467 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-05-20T13:34:27+00:00"
+            "time": "2025-12-08T14:27:58+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.10.3",
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c"
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/62d32998e820bddc40f99f8251958aed187a5c9c",
-                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:45:00+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
                 "shasum": ""
             },
             "require": {
@@ -341,11 +2350,6 @@
                 "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -389,22 +2393,76 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-09-18T10:38:58+00:00"
+            "time": "2025-11-04T16:30:35+00:00"
         },
         {
-            "name": "wp-coding-standards/wpcs",
-            "version": "3.1.0",
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/9333efcbff231f10dfd9c56bb7b65818b4733ca7",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
                 "shasum": ""
             },
             "require": {
@@ -412,17 +2470,17 @@
                 "ext-libxml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
-                "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.2.1",
-                "phpcsstandards/phpcsutils": "^1.0.10",
-                "squizlabs/php_codesniffer": "^3.9.0"
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.4"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
                 "phpcsstandards/phpcsdevtools": "^1.2.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "suggest": {
                 "ext-iconv": "For improved results",
@@ -457,17 +2515,80 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-03-25T16:39:00+00:00"
+            "time": "2025-11-25T12:08:04+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-08-10T05:13:49+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/inc/class-api-client.php
+++ b/inc/class-api-client.php
@@ -1,0 +1,259 @@
+<?php
+namespace Ancozockt\Umami;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class ApiClient
+ *
+ * Communicates with the Umami Analytics API.
+ * Supports both self-hosted (token auth) and Umami Cloud (API key auth).
+ *
+ * @since 0.9.0
+ */
+class ApiClient {
+
+	/**
+	 * Base URL of the Umami instance (e.g. https://stats.example.com).
+	 *
+	 * @var string
+	 */
+	private string $base_url;
+
+	/**
+	 * The Umami website ID.
+	 *
+	 * @var string
+	 */
+	private string $website_id;
+
+	/**
+	 * Username for self-hosted authentication.
+	 *
+	 * @var string
+	 */
+	private string $username;
+
+	/**
+	 * Password for self-hosted authentication.
+	 *
+	 * @var string
+	 */
+	private string $password;
+
+	/**
+	 * API key for Umami Cloud authentication.
+	 *
+	 * @var string
+	 */
+	private string $api_key;
+
+	/**
+	 * Bearer token obtained from self-hosted login.
+	 *
+	 * @var string
+	 */
+	private string $token = '';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $base_url   The Umami instance base URL.
+	 * @param string $website_id The website ID.
+	 * @param string $username   Username for self-hosted auth (optional).
+	 * @param string $password   Password for self-hosted auth (optional).
+	 * @param string $api_key    API key for Cloud auth (optional).
+	 */
+	public function __construct(
+		string $base_url,
+		string $website_id,
+		string $username = '',
+		string $password = '',
+		string $api_key = ''
+	) {
+		$this->base_url   = rtrim( $base_url, '/' );
+		$this->website_id = $website_id;
+		$this->username   = $username;
+		$this->password   = $password;
+		$this->api_key    = $api_key;
+	}
+
+	/**
+	 * Create an ApiClient from the saved WordPress options.
+	 *
+	 * @return self|null The client instance, or null if not configured.
+	 */
+	public static function from_options(): ?self {
+		$options    = Options::get_options();
+		$website_id = trim( $options['website_id'] ?? '' );
+		$host_url   = trim( $options['host_url'] ?? '' );
+		$script_url = trim( $options['script_url'] ?? '' );
+
+		if ( empty( $website_id ) ) {
+			return null;
+		}
+
+		// Derive the base URL from host_url or script_url.
+		if ( ! empty( $host_url ) ) {
+			$base_url = $host_url;
+		} elseif ( ! empty( $script_url ) ) {
+			$parsed   = wp_parse_url( $script_url );
+			$base_url = ( $parsed['scheme'] ?? 'https' ) . '://' . ( $parsed['host'] ?? '' );
+		} else {
+			return null;
+		}
+
+		$api_key  = trim( $options['api_key'] ?? '' );
+		$username = trim( $options['api_username'] ?? '' );
+		$password = trim( $options['api_password'] ?? '' );
+
+		return new self( $base_url, $website_id, $username, $password, $api_key );
+	}
+
+	/**
+	 * Whether this client targets Umami Cloud.
+	 *
+	 * @return bool
+	 */
+	public function is_cloud(): bool {
+		return str_contains( $this->base_url, 'umami.is' );
+	}
+
+	/**
+	 * Get authentication headers for API requests.
+	 *
+	 * @return array Associative array of HTTP headers.
+	 */
+	public function get_auth_headers(): array {
+		// Cloud: use API key header.
+		if ( ! empty( $this->api_key ) ) {
+			return array( 'x-umami-api-key' => $this->api_key );
+		}
+
+		// Self-hosted: use Bearer token (must call login() first).
+		if ( ! empty( $this->token ) ) {
+			return array( 'Authorization' => 'Bearer ' . $this->token );
+		}
+
+		return array();
+	}
+
+	/**
+	 * Authenticate with a self-hosted Umami instance.
+	 *
+	 * @return bool True if login succeeded.
+	 */
+	public function login(): bool {
+		$response = wp_remote_post(
+			$this->base_url . '/api/auth/login',
+			array(
+				'headers' => array( 'Content-Type' => 'application/json' ),
+				'body'    => wp_json_encode(
+					array(
+						'username' => $this->username,
+						'password' => $this->password,
+					)
+				),
+				'timeout' => 15,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $code ) {
+			return false;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! isset( $body['token'] ) ) {
+			return false;
+		}
+
+		$this->token = $body['token'];
+		return true;
+	}
+
+	/**
+	 * Fetch website statistics for a date range.
+	 *
+	 * @param string $start_date Start date (ISO 8601 or timestamp).
+	 * @param string $end_date   End date (ISO 8601 or timestamp).
+	 *
+	 * @return array|null Stats array or null on failure.
+	 */
+	public function get_stats( string $start_date, string $end_date ): ?array {
+		$url = $this->base_url . '/api/websites/' . $this->website_id . '/stats'
+			. '?startAt=' . $this->to_timestamp( $start_date )
+			. '&endAt=' . $this->to_timestamp( $end_date );
+
+		return $this->api_get( $url );
+	}
+
+	/**
+	 * Fetch the number of active visitors.
+	 *
+	 * @return int|null Active visitor count or null on failure.
+	 */
+	public function get_active_visitors(): ?int {
+		$url    = $this->base_url . '/api/websites/' . $this->website_id . '/active';
+		$result = $this->api_get( $url );
+
+		if ( null === $result ) {
+			return null;
+		}
+
+		return (int) ( $result['x'] ?? 0 );
+	}
+
+	/**
+	 * Make an authenticated GET request.
+	 *
+	 * @param string $url The full URL.
+	 *
+	 * @return array|null Decoded JSON response or null on failure.
+	 */
+	private function api_get( string $url ): ?array {
+		$response = wp_remote_get(
+			$url,
+			array(
+				'headers' => array_merge(
+					array( 'Accept' => 'application/json' ),
+					$this->get_auth_headers()
+				),
+				'timeout' => 15,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $code ) {
+			return null;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		return is_array( $body ) ? $body : null;
+	}
+
+	/**
+	 * Convert a date string to a Unix timestamp in milliseconds.
+	 *
+	 * @param string $date Date string or numeric timestamp.
+	 *
+	 * @return int Timestamp in milliseconds.
+	 */
+	private function to_timestamp( string $date ): int {
+		if ( is_numeric( $date ) ) {
+			return (int) $date;
+		}
+
+		return (int) ( strtotime( $date ) * 1000 );
+	}
+}

--- a/inc/class-dashboard-widget.php
+++ b/inc/class-dashboard-widget.php
@@ -45,6 +45,7 @@ class DashboardWidget {
 	 *
 	 * @since 0.8.0
 	 * @change 0.8.1 - Path changed in umami.
+	 * @change 0.9.0 - Show live stats via API when configured.
 	 */
 	public function render_widget() {
 		$options    = Options::get_options();
@@ -53,29 +54,131 @@ class DashboardWidget {
 		$script_url = $options['script_url'];
 
 		// Check if the settings are configured.
-		if ( ! empty( $website_id ) && ! empty( $script_url ) ) {
-			if ( empty( $host_url ) ) {
-				$host_url = wp_parse_url( $script_url, PHP_URL_SCHEME ) . '://' . wp_parse_url( $script_url, PHP_URL_HOST );
-			}
-			$url = $host_url . '/websites/' . $website_id;
+		if ( empty( $website_id ) || empty( $script_url ) ) {
 			echo wp_kses(
-				// translators: %s => Umami Admin page URL.
-				sprintf( __( 'View you analytics on <a href="%s" target="_blank">Umami Analytics</a>', 'integrate-umami' ), esc_url( $url ) ),
-				array(
-					'a' => array(
-						'href'   => array(),
-						'target' => array(),
-					),
-				)
+				__( 'Please configure the Umami Analytics settings.', 'integrate-umami' ),
+				array( 'p' => array() )
 			);
 			return;
 		}
 
+		// Try to fetch live stats via API.
+		$this->render_api_stats( $options );
+
+		// Always show the link to Umami.
+		if ( empty( $host_url ) ) {
+			$host_url = wp_parse_url( $script_url, PHP_URL_SCHEME ) . '://' . wp_parse_url( $script_url, PHP_URL_HOST );
+		}
+		$url = $host_url . '/websites/' . $website_id;
+		echo '<p>';
 		echo wp_kses(
-			__( 'Please configure the Umami Analytics settings.', 'integrate-umami' ),
+			// translators: %s => Umami Admin page URL.
+			sprintf( __( 'View full analytics on <a href="%s" target="_blank">Umami Analytics</a>', 'integrate-umami' ), esc_url( $url ) ),
 			array(
-				'p' => array(),
+				'a' => array(
+					'href'   => array(),
+					'target' => array(),
+				),
 			)
 		);
+		echo '</p>';
+	}
+
+	/**
+	 * Render API-powered stats if credentials are configured.
+	 *
+	 * @param array $options Plugin options.
+	 *
+	 * @since 0.9.0
+	 */
+	private function render_api_stats( array $options ) {
+		$has_api_key  = ! empty( $options['api_key'] );
+		$has_api_creds = ! empty( $options['api_username'] ) && ! empty( $options['api_password'] );
+
+		if ( ! $has_api_key && ! $has_api_creds ) {
+			return;
+		}
+
+		// Use a transient to cache stats for 5 minutes.
+		$cache_key = 'integrate_umami_stats_' . md5( $options['website_id'] );
+		$cached    = get_transient( $cache_key );
+
+		if ( false !== $cached ) {
+			$this->render_stats_html( $cached );
+			return;
+		}
+
+		$client = ApiClient::from_options();
+		if ( null === $client ) {
+			return;
+		}
+
+		// For self-hosted, login first.
+		if ( ! $client->is_cloud() && $has_api_creds ) {
+			if ( ! $client->login() ) {
+				echo '<p><em>' . esc_html__( 'Could not connect to Umami API. Check your credentials.', 'integrate-umami' ) . '</em></p>';
+				return;
+			}
+		}
+
+		// Fetch last 30 days of stats.
+		$end_date   = gmdate( 'Y-m-d' );
+		$start_date = gmdate( 'Y-m-d', strtotime( '-30 days' ) );
+		$stats      = $client->get_stats( $start_date, $end_date );
+		$active     = $client->get_active_visitors();
+
+		if ( null === $stats ) {
+			echo '<p><em>' . esc_html__( 'Could not fetch analytics data.', 'integrate-umami' ) . '</em></p>';
+			return;
+		}
+
+		$data = array(
+			'pageviews' => $stats['pageviews']['value'] ?? 0,
+			'visitors'  => $stats['visitors']['value'] ?? 0,
+			'visits'    => $stats['visits']['value'] ?? 0,
+			'bounces'   => $stats['bounces']['value'] ?? 0,
+			'active'    => $active ?? 0,
+		);
+
+		set_transient( $cache_key, $data, 5 * MINUTE_IN_SECONDS );
+		$this->render_stats_html( $data );
+	}
+
+	/**
+	 * Output the stats HTML.
+	 *
+	 * @param array $data Stats data array.
+	 *
+	 * @since 0.9.0
+	 */
+	private function render_stats_html( array $data ) {
+		?>
+		<div class="integrate-umami-stats" style="display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-bottom:12px;">
+			<div style="text-align:center;padding:8px;background:#f0f0f1;border-radius:4px;">
+				<div style="font-size:24px;font-weight:600;color:#1d2327;"><?php echo esc_html( number_format_i18n( $data['pageviews'] ) ); ?></div>
+				<div style="font-size:12px;color:#50575e;"><?php esc_html_e( 'Pageviews', 'integrate-umami' ); ?></div>
+			</div>
+			<div style="text-align:center;padding:8px;background:#f0f0f1;border-radius:4px;">
+				<div style="font-size:24px;font-weight:600;color:#1d2327;"><?php echo esc_html( number_format_i18n( $data['visitors'] ) ); ?></div>
+				<div style="font-size:12px;color:#50575e;"><?php esc_html_e( 'Visitors', 'integrate-umami' ); ?></div>
+			</div>
+			<div style="text-align:center;padding:8px;background:#f0f0f1;border-radius:4px;">
+				<div style="font-size:24px;font-weight:600;color:#2271b1;"><?php echo esc_html( number_format_i18n( $data['active'] ) ); ?></div>
+				<div style="font-size:12px;color:#50575e;"><?php esc_html_e( 'Active Now', 'integrate-umami' ); ?></div>
+			</div>
+		</div>
+		<p style="font-size:12px;color:#787c82;margin:0 0 8px;">
+			<?php
+			echo esc_html(
+				sprintf(
+					// translators: %1$s visits, %2$s bounces.
+					__( '%1$s visits, %2$s bounces in the last 30 days', 'integrate-umami' ),
+					number_format_i18n( $data['visits'] ),
+					number_format_i18n( $data['bounces'] )
+				)
+			);
+			?>
+		</p>
+		<?php
 	}
 }

--- a/inc/class-manager.php
+++ b/inc/class-manager.php
@@ -33,8 +33,7 @@ class Manager {
 				add_action( 'wp_footer', array( $this, 'render_script' ) );
 
 				if ( isset( $options['track_comments'] ) && $options['track_comments'] === 1 ) {
-					// Add filters to add event data attributes.
-					add_filter( 'comment_form_submit_button', array( $this, 'filter_comment_form_submit_button' ), 10, 1 );
+					add_action( 'wp_footer', array( $this, 'render_comment_tracking_script' ) );
 				}
 			}
 		}
@@ -54,32 +53,43 @@ class Manager {
 	}
 
 	/**
-	 * Filter comment submit button to add data attribute.
+	 * Render JavaScript snippet for comment form event tracking.
 	 *
-	 * @param string $submit_button The submit button.
+	 * Replaces the old PHP regex approach (filter_comment_form_submit_button)
+	 * which was fragile and broke with custom themes and comment plugins (#39).
+	 * This JS-based approach dynamically finds the comment form submit button
+	 * at DOM ready, working with native WP comments, wpDiscuz, and most plugins.
 	 *
-	 * @since 0.6.0
-	 * @change 0.8.3 - Fix bug with comment form submit button.
-	 * @change 0.8.3 - Add more meta data attributes.
+	 * @since 0.9.0
 	 */
-	public function filter_comment_form_submit_button( string $submit_button ) {
-		$post_id = get_the_ID();
-
-		$data_attributes = 'data-umami-event="comment" ';
-		if ( $post_id !== false && is_numeric( $post_id ) ) {
-			$post_title = get_the_title( $post_id );
-			if ( strlen( $post_title ) > 50 ) {
-				$post_title = substr( $post_title, 0, 50 ) . '...';
+	public function render_comment_tracking_script() {
+		?>
+		<!-- Integrate Umami: Comment Tracking -->
+		<script>
+		(function() {
+			var selectors = [
+				'#commentform input[type="submit"]',
+				'#commentform button[type="submit"]',
+				'.comment-form input[type="submit"]',
+				'.comment-form button[type="submit"]'
+			];
+			function attachTracking() {
+				for (var i = 0; i < selectors.length; i++) {
+					var btn = document.querySelector(selectors[i]);
+					if (btn && !btn.hasAttribute('data-umami-event')) {
+						btn.setAttribute('data-umami-event', 'comment');
+					}
+				}
 			}
-			$data_attributes .= 'data-umami-event-post-id="' . esc_attr( $post_id ) . '" ';
-			$data_attributes .= 'data-umami-event-post-title="' . esc_attr( $post_title ) . '" ';
-		}
-
-		// Check if $submit button is a "button" element.
-		if ( strpos( $submit_button, '<button' ) !== false ) {
-			return str_replace( '<button', '<input ' . $data_attributes, $submit_button );
-		}
-		return str_replace( '<input', '<input ' . $data_attributes, $submit_button );
+			if (document.readyState === 'loading') {
+				document.addEventListener('DOMContentLoaded', attachTracking);
+			} else {
+				attachTracking();
+			}
+		})();
+		</script>
+		<!-- /Integrate Umami: Comment Tracking -->
+		<?php
 	}
 
 	/**
@@ -98,26 +108,49 @@ class Manager {
 			return;
 		}
 
-		$umami_options = '';
-		if ( isset( $options['do_not_track'] ) && $options['do_not_track'] === 1 ) {
-			$umami_options .= 'data-do-not-track=true ';
+		// Trim whitespace from critical values (fixes copy-paste issues, #28).
+		$script_url = trim( $options['script_url'] ?? '' );
+		$website_id = trim( $options['website_id'] ?? '' );
+
+		$attrs = array();
+
+		if ( isset( $options['do_not_track'] ) && 1 === $options['do_not_track'] ) {
+			$attrs[] = 'data-do-not-track="true"';
 		}
-		if ( isset( $options['auto_track'] ) && $options['auto_track'] === 0 ) {
-			$umami_options .= 'data-auto-track=false ';
+		if ( isset( $options['auto_track'] ) && 0 === $options['auto_track'] ) {
+			$attrs[] = 'data-auto-track="false"';
 		}
-		if ( isset( $options['cache'] ) && $options['cache'] === 1 ) {
-			$umami_options .= 'data-cache=true ';
+		if ( isset( $options['cache'] ) && 1 === $options['cache'] ) {
+			$attrs[] = 'data-cache="true"';
 		}
-		if ( ! empty( $options['host_url'] ) && isset( $options['use_host_url'] ) && $options['use_host_url'] === 1 ) {
-			$umami_options .= 'data-host-url=' . esc_url( $options['host_url'] );
+		if ( ! empty( $options['host_url'] ) && isset( $options['use_host_url'] ) && 1 === $options['use_host_url'] ) {
+			$attrs[] = 'data-host-url="' . esc_url( trim( $options['host_url'] ) ) . '"';
 		}
+
+		// v3 tracker attributes.
+		if ( ! empty( $options['tag'] ) ) {
+			$attrs[] = 'data-tag="' . esc_attr( trim( $options['tag'] ) ) . '"';
+		}
+		if ( ! empty( $options['domains'] ) ) {
+			$attrs[] = 'data-domains="' . esc_attr( trim( $options['domains'] ) ) . '"';
+		}
+		if ( isset( $options['exclude_search'] ) && 1 === $options['exclude_search'] ) {
+			$attrs[] = 'data-exclude-search="true"';
+		}
+		if ( isset( $options['exclude_hash'] ) && 1 === $options['exclude_hash'] ) {
+			$attrs[] = 'data-exclude-hash="true"';
+		}
+		if ( ! empty( $options['before_send'] ) ) {
+			$attrs[] = 'data-before-send="' . esc_attr( trim( $options['before_send'] ) ) . '"';
+		}
+
+		$extra_attrs = ! empty( $attrs ) ? "\n\t\t\t\t" . implode( "\n\t\t\t\t", $attrs ) : '';
 
 		?>
 		<!-- Integrate Umami -->
 		<script async defer
-				src="<?php echo esc_url( $options['script_url'] ); ?>"
-				data-website-id="<?php esc_attr_e( $options['website_id'] ); ?>"
-				<?php esc_attr_e( $umami_options ); ?>>
+				src="<?php echo esc_url( $script_url ); ?>"
+				data-website-id="<?php echo esc_attr( $website_id ); ?>"<?php echo $extra_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- all values escaped above. ?>>
 		</script>
 		<!-- /Integrate Umami -->
 		<?php

--- a/inc/class-options.php
+++ b/inc/class-options.php
@@ -36,6 +36,14 @@ class Options {
 				'do_not_track'   => 1,
 				'cache'          => 0,
 				'track_comments' => 0,
+				'tag'            => '',
+				'domains'        => '',
+				'exclude_search' => 0,
+				'exclude_hash'   => 0,
+				'before_send'    => '',
+				'api_key'        => '',
+				'api_username'   => '',
+				'api_password'   => '',
 			)
 		);
 	}

--- a/inc/class-settings.php
+++ b/inc/class-settings.php
@@ -125,17 +125,31 @@ class Settings {
 			return array();
 		}
 
+		// Sanitize before_send: only allow valid JS identifier patterns.
+		$before_send = sanitize_text_field( $data['before_send'] ?? '' );
+		if ( '' !== $before_send && ! preg_match( '/^[a-zA-Z_$][a-zA-Z0-9_$.]*$/', $before_send ) ) {
+			$before_send = '';
+		}
+
 		return array(
 			'enabled'        => (int) ( $data['enabled'] ?? false ),
-			'script_url'     => esc_url_raw( $data['script_url'] ),
-			'website_id'     => sanitize_text_field( $data['website_id'] ),
-			'host_url'       => esc_url_raw( $data['host_url'] ),
+			'script_url'     => esc_url_raw( trim( $data['script_url'] ?? '' ) ),
+			'website_id'     => sanitize_text_field( trim( $data['website_id'] ?? '' ) ),
+			'host_url'       => esc_url_raw( trim( $data['host_url'] ?? '' ) ),
 			'use_host_url'   => (int) ( $data['use_host_url'] ?? false ),
 			'ignore_admins'  => (int) ( $data['ignore_admins'] ?? false ),
 			'auto_track'     => (int) ( $data['auto_track'] ?? false ),
 			'do_not_track'   => (int) ( $data['do_not_track'] ?? false ),
 			'cache'          => (int) ( $data['cache'] ?? false ),
 			'track_comments' => (int) ( $data['track_comments'] ?? false ),
+			'tag'            => sanitize_text_field( $data['tag'] ?? '' ),
+			'domains'        => sanitize_text_field( $data['domains'] ?? '' ),
+			'exclude_search' => (int) ( $data['exclude_search'] ?? false ),
+			'exclude_hash'   => (int) ( $data['exclude_hash'] ?? false ),
+			'before_send'    => $before_send,
+			'api_key'        => sanitize_text_field( $data['api_key'] ?? '' ),
+			'api_username'   => sanitize_text_field( $data['api_username'] ?? '' ),
+			'api_password'   => sanitize_text_field( $data['api_password'] ?? '' ),
 		);
 	}
 

--- a/inc/templates/settings-page.php
+++ b/inc/templates/settings-page.php
@@ -34,7 +34,17 @@
 			<td>
 				<input class="integrate-umami-url" type="url" name="integrate_umami_options[script_url]" id="integrate_umami_script_url"
 					value="<?php echo esc_attr( $options['script_url'] ); ?>"/>
-				<p class="description"><?php esc_html_e( 'The url to your umami tracking script', 'integrate-umami' ); ?></p>
+				<p class="description">
+					<?php
+					echo wp_kses(
+						__( 'The URL to your Umami tracking script.<br>Self-hosted: typically <code>https://your-domain.com/script.js</code><br>Umami Cloud: use <code>https://cloud.umami.is/script.js</code>', 'integrate-umami' ),
+						array(
+							'br'   => array(),
+							'code' => array(),
+						)
+					);
+					?>
+				</p>
 			</td>
 		</tr>
 
@@ -118,14 +128,14 @@
 						<label for="integrate_umami_auto_track">
 							<input type="checkbox" name="integrate_umami_options[auto_track]" id="integrate_umami_auto_track"
 								value="1" <?php checked( $options['auto_track'] ); ?> />
-							<?php esc_html_e( 'Enable the automatic events and pageviews tracking', 'integrate-umami' ); ?>
+							<?php esc_html_e( 'Automatically track page views and outbound link clicks', 'integrate-umami' ); ?>
 							<p class="description">
 								<?php
 								echo wp_kses(
-									__( '<b>Note</b>: You need to add your own <a href="https://umami.is/docs/tracker-functions">Tracker functions</a> when disabled.', 'integrate-umami' ),
+									__( 'When disabled, you must call <code>umami.track()</code> manually in your theme or plugin code. See <a href="https://umami.is/docs/tracker-functions">Tracker functions</a>.', 'integrate-umami' ),
 									array(
-										'b' => array(),
-										'a' => array(
+										'code' => array(),
+										'a'    => array(
 											'href' => array(),
 										),
 									)
@@ -180,16 +190,17 @@
 				<tr>
 					<th class="row">
 						<?php esc_html_e( 'Cache', 'integrate-umami' ); ?>
+						<span style="color: #d63638; font-size: 11px; font-weight: normal;"><?php esc_html_e( '(Deprecated)', 'integrate-umami' ); ?></span>
 					</th>
 					<td>
 						<label for="integrate_umami_cache">
 							<input type="checkbox" name="integrate_umami_options[cache]" id="integrate_umami_cache"
 								value="1" <?php checked( $options['cache'] ); ?> />
-							<?php esc_html_e( 'Enable caching of tracking data for better performance', 'integrate-umami' ); ?>
-							<p class="description">
+							<?php esc_html_e( 'Enable caching of tracking data using session storage', 'integrate-umami' ); ?>
+							<p class="description" style="color: #d63638;">
 								<?php
 								echo wp_kses(
-									__( '<b>Note</b>: This will use session storage, so you may need to inform your users. (Not Supported by Umami v2)', 'integrate-umami' ),
+									__( '<b>Deprecated:</b> This option has been removed in Umami v3 and will be removed from this plugin in a future release.', 'integrate-umami' ),
 									array(
 										'b' => array(),
 									)
@@ -197,6 +208,160 @@
 								?>
 							</p>
 						</label>
+					</td>
+				</tr>
+				<tr>
+					<th class="row">
+						<?php esc_html_e( 'Tag', 'integrate-umami' ); ?>
+					</th>
+					<td>
+						<input class="integrate-umami-text" type="text" name="integrate_umami_options[tag]" id="integrate_umami_tag"
+							value="<?php echo esc_attr( $options['tag'] ); ?>"/>
+						<p class="description">
+							<?php
+							echo wp_kses(
+								__( 'Assign a tag to group tracked events. Useful for A/B testing. See <a href="https://umami.is/docs/tracker-configuration">Tracker configuration</a>.', 'integrate-umami' ),
+								array(
+									'a' => array(
+										'href' => array(),
+									),
+								)
+							);
+							?>
+						</p>
+					</td>
+				</tr>
+
+				<tr>
+					<th class="row">
+						<?php esc_html_e( 'Domains', 'integrate-umami' ); ?>
+					</th>
+					<td>
+						<input class="integrate-umami-text" type="text" name="integrate_umami_options[domains]" id="integrate_umami_domains"
+							value="<?php echo esc_attr( $options['domains'] ); ?>"/>
+						<p class="description">
+							<?php esc_html_e( 'Comma-separated list of domains where tracking is active. Leave empty to track on all domains.', 'integrate-umami' ); ?>
+						</p>
+					</td>
+				</tr>
+
+				<tr>
+					<th class="row">
+						<?php esc_html_e( 'Exclude Search Params', 'integrate-umami' ); ?>
+					</th>
+					<td>
+						<label for="integrate_umami_exclude_search">
+							<input type="checkbox" name="integrate_umami_options[exclude_search]" id="integrate_umami_exclude_search"
+								value="1" <?php checked( $options['exclude_search'] ); ?> />
+							<?php esc_html_e( 'Exclude URL query parameters from tracked page URLs', 'integrate-umami' ); ?>
+							<p class="description">
+								<?php esc_html_e( 'Removes ?query=string from tracked URLs. Requires Umami v3.', 'integrate-umami' ); ?>
+							</p>
+						</label>
+					</td>
+				</tr>
+
+				<tr>
+					<th class="row">
+						<?php esc_html_e( 'Exclude Hash', 'integrate-umami' ); ?>
+					</th>
+					<td>
+						<label for="integrate_umami_exclude_hash">
+							<input type="checkbox" name="integrate_umami_options[exclude_hash]" id="integrate_umami_exclude_hash"
+								value="1" <?php checked( $options['exclude_hash'] ); ?> />
+							<?php esc_html_e( 'Exclude URL hash fragments from tracked page URLs', 'integrate-umami' ); ?>
+							<p class="description">
+								<?php esc_html_e( 'Removes #fragment from tracked URLs. Requires Umami v3.', 'integrate-umami' ); ?>
+							</p>
+						</label>
+					</td>
+				</tr>
+
+				<tr>
+					<th class="row">
+						<?php esc_html_e( 'Before Send Function', 'integrate-umami' ); ?>
+					</th>
+					<td>
+						<input class="integrate-umami-text" type="text" name="integrate_umami_options[before_send]" id="integrate_umami_before_send"
+							value="<?php echo esc_attr( $options['before_send'] ); ?>"/>
+						<p class="description">
+							<?php
+							echo wp_kses(
+								__( 'Name of a JavaScript function to intercept tracking data before it is sent. The function receives <code>(type, payload)</code> and should return the modified payload, or a falsy value to cancel the request. Requires Umami v3.', 'integrate-umami' ),
+								array(
+									'code' => array(),
+								)
+							);
+							?>
+						</p>
+					</td>
+				</tr>
+			</table>
+		</div>
+	</div>
+
+	<div class="integrate-umami-collapsed">
+		<input class="toggle" id="api-options" type="checkbox">
+		<label class="toggle-label" for="api-options"><?php esc_html_e( 'API Connection (Optional)', 'integrate-umami' ); ?></label>
+		<div class="content">
+			<p class="description">
+				<?php
+				echo wp_kses(
+					__( 'Connect to the Umami API to display analytics in your WordPress dashboard. For Umami Cloud, use an API key. For self-hosted instances, use your Umami username and password. See <a href="https://umami.is/docs/api">API documentation</a>.', 'integrate-umami' ),
+					array(
+						'a' => array(
+							'href' => array(),
+						),
+					)
+				);
+				?>
+			</p>
+			<table class="form-table">
+				<tr>
+					<th class="row">
+						<?php esc_html_e( 'API Key', 'integrate-umami' ); ?>
+					</th>
+					<td>
+						<input class="integrate-umami-text" type="password" name="integrate_umami_options[api_key]" id="integrate_umami_api_key"
+							value="<?php echo esc_attr( $options['api_key'] ); ?>" autocomplete="off"/>
+						<p class="description">
+							<?php
+							echo wp_kses(
+								__( 'For Umami Cloud: create an API key at Settings &gt; API Keys in your <a href="https://cloud.umami.is">Umami Cloud</a> dashboard.', 'integrate-umami' ),
+								array(
+									'a' => array(
+										'href' => array(),
+									),
+								)
+							);
+							?>
+						</p>
+					</td>
+				</tr>
+
+				<tr>
+					<th class="row">
+						<?php esc_html_e( 'API Username', 'integrate-umami' ); ?>
+					</th>
+					<td>
+						<input class="integrate-umami-text" type="text" name="integrate_umami_options[api_username]" id="integrate_umami_api_username"
+							value="<?php echo esc_attr( $options['api_username'] ); ?>" autocomplete="off"/>
+						<p class="description">
+							<?php esc_html_e( 'For self-hosted Umami: your Umami admin username.', 'integrate-umami' ); ?>
+						</p>
+					</td>
+				</tr>
+
+				<tr>
+					<th class="row">
+						<?php esc_html_e( 'API Password', 'integrate-umami' ); ?>
+					</th>
+					<td>
+						<input class="integrate-umami-text" type="password" name="integrate_umami_options[api_password]" id="integrate_umami_api_password"
+							value="<?php echo esc_attr( $options['api_password'] ); ?>" autocomplete="off"/>
+						<p class="description">
+							<?php esc_html_e( 'For self-hosted Umami: your Umami admin password.', 'integrate-umami' ); ?>
+						</p>
 					</td>
 				</tr>
 			</table>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/phpunit/bootstrap.php"
+	colors="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+>
+	<testsuites>
+		<testsuite name="unit">
+			<directory suffix="Test.php">tests/phpunit/unit</directory>
+		</testsuite>
+	</testsuites>
+	<coverage>
+		<include>
+			<directory suffix=".php">inc</directory>
+			<file>wp-umami.php</file>
+		</include>
+	</coverage>
+</phpunit>

--- a/tests/comment-tracking.test.js
+++ b/tests/comment-tracking.test.js
@@ -1,0 +1,84 @@
+const {test, expect} = require('@playwright/test')
+const {updateOption, runCommand} = require("./helper/wpcli-command");
+const TEST_USER = process.env.TEST_USER || 'admin'
+const TEST_PASS = process.env.TEST_PASS || 'password'
+
+/**
+ * E2E tests for comment form event tracking (#39).
+ * Verifies the JS-based approach correctly adds data-umami-event
+ * attributes to comment form submit buttons.
+ */
+
+test.describe('comment event tracking', () => {
+
+    test.beforeEach(async ({page}) => {
+        updateOption('integrate_umami_options', {
+            enabled: 1,
+            script_url: 'https://stats.wavedepth.com/script.js',
+            website_id: '837d5df1-a19a-4cac-831c-34a53ab951b5',
+            host_url: '',
+            use_host_url: 0,
+            ignore_admins: 0,
+            auto_track: 1,
+            do_not_track: 0,
+            cache: 0,
+            track_comments: 1,
+            tag: '',
+            domains: '',
+            exclude_search: 0,
+            exclude_hash: 0,
+            before_send: ''
+        });
+    });
+
+    test('injects comment tracking JS when track_comments enabled', async ({page}) => {
+        // Need a post with comments open. Create one via WP-CLI (no spaces in title).
+        const postId = runCommand('post create --post_title=CommentTestPost --post_status=publish --comment_status=open --porcelain').trim();
+
+        await page.goto(`/?p=${postId}`, {waitUntil: 'networkidle'});
+
+        // The comment tracking script should be present in the page source.
+        const html = await page.content();
+        expect(html).toContain('Integrate Umami: Comment Tracking');
+
+        // If the comment form is rendered (depends on theme), the submit button
+        // should get the data-umami-event attribute via the JS snippet.
+        const submitBtn = page.locator('#commentform input[type="submit"], #commentform button[type="submit"]');
+        if (await submitBtn.count() > 0) {
+            await expect(submitBtn.first()).toHaveAttribute('data-umami-event', 'comment');
+        }
+
+        // Clean up test post.
+        runCommand(`post delete ${postId} --force`);
+    });
+
+    test('does NOT inject comment tracking JS when disabled', async ({page}) => {
+        updateOption('integrate_umami_options', {
+            enabled: 1,
+            script_url: 'https://stats.wavedepth.com/script.js',
+            website_id: '837d5df1-a19a-4cac-831c-34a53ab951b5',
+            host_url: '',
+            use_host_url: 0,
+            ignore_admins: 0,
+            auto_track: 1,
+            do_not_track: 0,
+            cache: 0,
+            track_comments: 0,
+            tag: '',
+            domains: '',
+            exclude_search: 0,
+            exclude_hash: 0,
+            before_send: ''
+        });
+
+        const postId = runCommand('post create --post_title=NoCommentTracking --post_status=publish --comment_status=open --porcelain').trim();
+
+        await page.goto(`/?p=${postId}`, {waitUntil: 'networkidle'});
+
+        // The comment tracking script should NOT be present.
+        const html = await page.content();
+        expect(html).not.toContain('Integrate Umami: Comment Tracking');
+
+        runCommand(`post delete ${postId} --force`);
+    });
+});

--- a/tests/dashboard-widget.test.js
+++ b/tests/dashboard-widget.test.js
@@ -1,0 +1,106 @@
+const {test, expect} = require('@playwright/test')
+const {updateOption} = require("./helper/wpcli-command");
+const TEST_USER = process.env.TEST_USER || 'admin'
+const TEST_PASS = process.env.TEST_PASS || 'password'
+
+/**
+ * E2E tests for the dashboard widget with live Umami API data.
+ * Uses the live instance at stats.wavedepth.com.
+ */
+
+const LIVE_UMAMI_SCRIPT = 'https://stats.wavedepth.com/script.js'
+const LIVE_WEBSITE_ID = '837d5df1-a19a-4cac-831c-34a53ab951b5'
+
+test.describe('dashboard widget', () => {
+
+    test('shows link to Umami without API credentials', async ({page}) => {
+        updateOption('integrate_umami_options', {
+            enabled: 1,
+            script_url: LIVE_UMAMI_SCRIPT,
+            website_id: LIVE_WEBSITE_ID,
+            host_url: 'https://stats.wavedepth.com',
+            use_host_url: 0,
+            ignore_admins: 0,
+            auto_track: 1,
+            do_not_track: 0,
+            cache: 0,
+            track_comments: 0,
+            tag: '',
+            domains: '',
+            exclude_search: 0,
+            exclude_hash: 0,
+            before_send: '',
+            api_key: '',
+            api_username: '',
+            api_password: ''
+        });
+
+        await login(page);
+        // Navigate to dashboard.
+        await page.goto('/wp-admin/', {waitUntil: 'networkidle'});
+
+        // The widget should exist.
+        const widget = page.locator('#umami_widget');
+        await expect(widget).toBeVisible();
+
+        // Should show link to Umami.
+        const link = widget.locator('a[href*="stats.wavedepth.com"]');
+        await expect(link).toBeVisible();
+    });
+
+    test('shows API connection section in settings', async ({page}) => {
+        await login(page);
+        await switchToSettings(page);
+
+        // Expand API section.
+        await page.locator('label[for="api-options"]').click();
+
+        // Verify API fields exist.
+        await expect(page.locator('#integrate_umami_api_key')).toBeVisible();
+        await expect(page.locator('#integrate_umami_api_username')).toBeVisible();
+        await expect(page.locator('#integrate_umami_api_password')).toBeVisible();
+    });
+
+    test('saves API credentials via settings page', async ({page}) => {
+        await login(page);
+        await switchToSettings(page);
+
+        // Expand API section and enter credentials.
+        await page.locator('label[for="api-options"]').click();
+        await page.locator('#integrate_umami_api_username').fill('admin');
+        await page.locator('#integrate_umami_api_password').fill('testpass');
+        await page.getByRole('button', {name: 'Save Changes'}).click();
+
+        // Verify page reloads and credentials are saved.
+        await page.locator('label[for="api-options"]').click();
+        await expect(page.locator('#integrate_umami_api_username')).toHaveValue('admin');
+    });
+});
+
+async function login(page) {
+    await page.goto('/wp-login.php', {waitUntil: 'networkidle'})
+    await expect(page).toHaveTitle(/Log In/)
+
+    await page.fill('#user_login', TEST_USER)
+    await page.fill('#user_pass', TEST_PASS)
+    await page.click('#wp-submit')
+
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveTitle(/Dashboard/)
+}
+
+async function switchToSettings(page) {
+    const menu = await page.locator('.wp-menu-name').getByText('Settings')
+    await expect(menu).toBeVisible();
+    await menu.click()
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveTitle(/General Settings/)
+
+    const settings = await page.locator('a').getByText('Integrate Umami')
+    await expect(settings).toBeVisible();
+    await settings.click()
+    await page.waitForLoadState('networkidle')
+
+    const title = await page.locator('h1').getByText('Integrate Umami Settings')
+    await expect(title).toBeVisible()
+}

--- a/tests/helper/wpcli-command.js
+++ b/tests/helper/wpcli-command.js
@@ -27,6 +27,50 @@ function runCommand(command, whiteSpaceArg = false) {
     return output;
 }
 
+/**
+ * Update a WordPress option with a JSON value, handling quoting properly.
+ * Passes the JSON value as a separate argument to avoid shell escaping issues.
+ *
+ * @param {string} optionName - The option name.
+ * @param {object} value - The value to set (will be JSON.stringify'd).
+ */
+function updateOption(optionName, value) {
+    const WP_ENV = process.env.WP_ENV || 'main';
+    const container = (WP_ENV === 'test') ? 'tests-cli' : 'cli';
+    const jsonValue = JSON.stringify(value);
+
+    const args = ['run', 'env', 'run', container, '--', 'wp', 'option', 'update', optionName, jsonValue, '--format=json', '--quiet'];
+    const result = spawnSync('npm', args);
+
+    if (result.status !== 0) {
+        throw `updateOption("${optionName}") failed: ${result.stderr.toString()}`;
+    }
+}
+
+/**
+ * Get a WordPress option value as parsed JSON.
+ *
+ * @param {string} optionName - The option name.
+ * @returns {object} The parsed option value.
+ */
+function getOption(optionName) {
+    const WP_ENV = process.env.WP_ENV || 'main';
+    const container = (WP_ENV === 'test') ? 'tests-cli' : 'cli';
+
+    const args = ['run', 'env', 'run', container, '--', 'wp', 'option', 'get', optionName, '--format=json', '--quiet'];
+    const result = spawnSync('npm', args);
+
+    if (result.status !== 0) {
+        return undefined;
+    }
+
+    let output = result.stdout.toString().trim();
+    output = output.split('\n').slice(2).join('\n').trim();
+    return JSON.parse(output);
+}
+
 module.exports = {
-    runCommand
+    runCommand,
+    updateOption,
+    getOption
 };

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * PHPUnit bootstrap file for wp-umami unit tests.
+ *
+ * Uses WP_Mock to stub WordPress functions so tests run
+ * without a full WordPress installation.
+ *
+ * @package Integrate_Umami
+ */
+
+require_once dirname( __DIR__, 2 ) . '/vendor/autoload.php';
+
+WP_Mock::bootstrap();
+
+// Define WordPress constants that the plugin expects.
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', '/tmp/wordpress/' );
+}

--- a/tests/phpunit/unit/ApiClientTest.php
+++ b/tests/phpunit/unit/ApiClientTest.php
@@ -1,0 +1,323 @@
+<?php
+/**
+ * Unit tests for the ApiClient class.
+ *
+ * @package Integrate_Umami
+ */
+
+namespace Ancozockt\Umami\Tests;
+
+use WP_Mock;
+use WP_Mock\Tools\TestCase;
+use Ancozockt\Umami\ApiClient;
+
+/**
+ * Tests for ApiClient class — Umami API communication.
+ */
+class ApiClientTest extends TestCase {
+
+	/**
+	 * Test that the client can be constructed with self-hosted config.
+	 */
+	public function test_constructor_self_hosted() {
+		$client = new ApiClient(
+			'https://stats.example.com',
+			'test-website-id',
+			'admin',
+			'password123'
+		);
+
+		$this->assertInstanceOf( ApiClient::class, $client );
+	}
+
+	/**
+	 * Test that the client can be constructed with Cloud API key.
+	 */
+	public function test_constructor_cloud_api_key() {
+		$client = new ApiClient(
+			'https://api.umami.is',
+			'test-website-id',
+			'',
+			'',
+			'my-api-key-123'
+		);
+
+		$this->assertInstanceOf( ApiClient::class, $client );
+	}
+
+	/**
+	 * Test get_auth_headers returns API key header for Cloud.
+	 */
+	public function test_get_auth_headers_cloud() {
+		$client = new ApiClient(
+			'https://api.umami.is',
+			'test-website-id',
+			'',
+			'',
+			'my-api-key-123'
+		);
+
+		$headers = $client->get_auth_headers();
+
+		$this->assertArrayHasKey( 'x-umami-api-key', $headers );
+		$this->assertSame( 'my-api-key-123', $headers['x-umami-api-key'] );
+	}
+
+	/**
+	 * Test get_auth_headers returns empty for self-hosted without token.
+	 *
+	 * Before login, there's no token yet.
+	 */
+	public function test_get_auth_headers_self_hosted_no_token() {
+		$client = new ApiClient(
+			'https://stats.example.com',
+			'test-website-id',
+			'admin',
+			'password123'
+		);
+
+		$headers = $client->get_auth_headers();
+
+		// No token yet — should be empty (login not called).
+		$this->assertEmpty( $headers );
+	}
+
+	/**
+	 * Test login calls the correct API endpoint.
+	 */
+	public function test_login_makes_correct_request() {
+		WP_Mock::userFunction( 'wp_json_encode' )
+			->andReturnUsing( 'json_encode' );
+
+		WP_Mock::userFunction( 'wp_remote_post' )
+			->once()
+			->with(
+				'https://stats.example.com/api/auth/login',
+				\WP_Mock\Functions::type( 'array' )
+			)
+			->andReturn(
+				array(
+					'response' => array( 'code' => 200 ),
+					'body'     => json_encode( array( 'token' => 'test-bearer-token' ) ),
+				)
+			);
+
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )
+			->andReturn( 200 );
+
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->andReturn( json_encode( array( 'token' => 'test-bearer-token' ) ) );
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturn( false );
+
+		$client = new ApiClient(
+			'https://stats.example.com',
+			'test-website-id',
+			'admin',
+			'password123'
+		);
+
+		$result = $client->login();
+
+		$this->assertTrue( $result );
+
+		// After login, auth headers should contain Bearer token.
+		$headers = $client->get_auth_headers();
+		$this->assertArrayHasKey( 'Authorization', $headers );
+		$this->assertSame( 'Bearer test-bearer-token', $headers['Authorization'] );
+	}
+
+	/**
+	 * Test login returns false on failure.
+	 */
+	public function test_login_returns_false_on_failure() {
+		WP_Mock::userFunction( 'wp_json_encode' )
+			->andReturnUsing( 'json_encode' );
+
+		WP_Mock::userFunction( 'wp_remote_post' )
+			->andReturn(
+				array(
+					'response' => array( 'code' => 401 ),
+					'body'     => 'Unauthorized',
+				)
+			);
+
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )
+			->andReturn( 401 );
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturn( false );
+
+		$client = new ApiClient(
+			'https://stats.example.com',
+			'test-website-id',
+			'admin',
+			'wrongpassword'
+		);
+
+		$result = $client->login();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_stats builds correct URL and returns parsed data.
+	 */
+	public function test_get_stats_returns_parsed_data() {
+		$stats_response = array(
+			'pageviews' => array( 'value' => 1000, 'prev' => 800 ),
+			'visitors'  => array( 'value' => 250, 'prev' => 200 ),
+			'visits'    => array( 'value' => 400, 'prev' => 350 ),
+			'bounces'   => array( 'value' => 150, 'prev' => 120 ),
+		);
+
+		WP_Mock::userFunction( 'wp_remote_get' )
+			->once()
+			->andReturn(
+				array(
+					'response' => array( 'code' => 200 ),
+					'body'     => json_encode( $stats_response ),
+				)
+			);
+
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )
+			->andReturn( 200 );
+
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->andReturn( json_encode( $stats_response ) );
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturn( false );
+
+		$client = new ApiClient(
+			'https://api.umami.is',
+			'test-website-id',
+			'',
+			'',
+			'my-api-key'
+		);
+
+		$result = $client->get_stats( '2026-01-01', '2026-01-29' );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 1000, $result['pageviews']['value'] );
+		$this->assertSame( 250, $result['visitors']['value'] );
+	}
+
+	/**
+	 * Test get_stats returns null on error.
+	 */
+	public function test_get_stats_returns_null_on_error() {
+		$wp_error = new \stdClass();
+		$wp_error->errors = array( 'http_request_failed' => array( 'Connection timed out' ) );
+
+		WP_Mock::userFunction( 'wp_remote_get' )
+			->andReturn( $wp_error );
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturn( true );
+
+		$client = new ApiClient(
+			'https://api.umami.is',
+			'test-website-id',
+			'',
+			'',
+			'my-api-key'
+		);
+
+		$result = $client->get_stats( '2026-01-01', '2026-01-29' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test get_active_visitors returns integer count.
+	 */
+	public function test_get_active_visitors_returns_count() {
+		WP_Mock::userFunction( 'wp_remote_get' )
+			->once()
+			->andReturn(
+				array(
+					'response' => array( 'code' => 200 ),
+					'body'     => json_encode( array( 'x' => 5 ) ),
+				)
+			);
+
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )
+			->andReturn( 200 );
+
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )
+			->andReturn( json_encode( array( 'x' => 5 ) ) );
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturn( false );
+
+		$client = new ApiClient(
+			'https://stats.example.com',
+			'test-website-id',
+			'',
+			'',
+			'my-api-key'
+		);
+
+		$result = $client->get_active_visitors();
+
+		$this->assertSame( 5, $result );
+	}
+
+	/**
+	 * Test is_cloud returns true for cloud URLs.
+	 */
+	public function test_is_cloud_detects_cloud_instances() {
+		$client = new ApiClient(
+			'https://api.umami.is',
+			'test-id',
+			'',
+			'',
+			'key-123'
+		);
+
+		$this->assertTrue( $client->is_cloud() );
+	}
+
+	/**
+	 * Test is_cloud returns false for self-hosted.
+	 */
+	public function test_is_cloud_detects_self_hosted() {
+		$client = new ApiClient(
+			'https://stats.example.com',
+			'test-id',
+			'admin',
+			'pass'
+		);
+
+		$this->assertFalse( $client->is_cloud() );
+	}
+
+	/**
+	 * Test from_options factory creates client from WP options.
+	 */
+	public function test_from_options_factory() {
+		$test_options = array(
+			'enabled'    => 1,
+			'host_url'   => 'https://stats.example.com',
+			'website_id' => 'abc-123',
+			'script_url' => 'https://stats.example.com/script.js',
+		);
+
+		WP_Mock::userFunction( 'get_option' )
+			->andReturn( $test_options );
+
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+
+		$client = ApiClient::from_options();
+
+		$this->assertInstanceOf( ApiClient::class, $client );
+	}
+}

--- a/tests/phpunit/unit/ManagerTest.php
+++ b/tests/phpunit/unit/ManagerTest.php
@@ -1,0 +1,520 @@
+<?php
+/**
+ * Unit tests for the Manager class.
+ *
+ * @package Integrate_Umami
+ */
+
+namespace Ancozockt\Umami\Tests;
+
+use WP_Mock;
+use WP_Mock\Tools\TestCase;
+use Ancozockt\Umami\Manager;
+use Ancozockt\Umami\Options;
+
+/**
+ * Tests for Manager class — script rendering and comment tracking.
+ */
+class ManagerTest extends TestCase {
+
+	/**
+	 * Test render_script outputs correct script tag with basic options.
+	 *
+	 * This validates the esc_attr_e bug fix — the output must contain
+	 * the raw website ID value, not a translated string.
+	 */
+	public function test_render_script_outputs_correct_attributes() {
+		$test_options = array(
+			'enabled'        => 1,
+			'script_url'     => 'https://stats.example.com/script.js',
+			'website_id'     => 'abc-123-def-456',
+			'host_url'       => '',
+			'use_host_url'   => 0,
+			'ignore_admins'  => 0,
+			'auto_track'     => 1,
+			'do_not_track'   => 0,
+			'cache'          => 0,
+			'track_comments' => 0,
+			'tag'            => '',
+			'domains'        => '',
+			'exclude_search' => 0,
+			'exclude_hash'   => 0,
+			'before_send'    => '',
+		);
+
+		WP_Mock::userFunction( 'get_option' )
+			->andReturn( $test_options );
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+		WP_Mock::userFunction( 'current_user_can' )->andReturn( false );
+		WP_Mock::passthruFunction( 'esc_url' );
+		WP_Mock::passthruFunction( 'esc_attr' );
+
+		$manager = $this->getMockBuilder( Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		ob_start();
+		$manager->render_script();
+		$output = ob_get_clean();
+
+		// Must contain the script URL.
+		$this->assertStringContainsString( 'src="https://stats.example.com/script.js"', $output );
+
+		// Must contain the website ID as a data attribute value.
+		$this->assertStringContainsString( 'data-website-id="abc-123-def-456"', $output );
+
+		// Must NOT contain data-do-not-track (disabled).
+		$this->assertStringNotContainsString( 'data-do-not-track', $output );
+
+		// Must NOT contain data-auto-track=false (auto_track is enabled).
+		$this->assertStringNotContainsString( 'data-auto-track=false', $output );
+	}
+
+	/**
+	 * Test render_script includes do-not-track when enabled.
+	 */
+	public function test_render_script_includes_do_not_track() {
+		$test_options = array(
+			'enabled'        => 1,
+			'script_url'     => 'https://stats.example.com/script.js',
+			'website_id'     => 'test-id',
+			'host_url'       => '',
+			'use_host_url'   => 0,
+			'ignore_admins'  => 0,
+			'auto_track'     => 1,
+			'do_not_track'   => 1,
+			'cache'          => 0,
+			'track_comments' => 0,
+			'tag'            => '',
+			'domains'        => '',
+			'exclude_search' => 0,
+			'exclude_hash'   => 0,
+			'before_send'    => '',
+		);
+
+		WP_Mock::userFunction( 'get_option' )->andReturn( $test_options );
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+		WP_Mock::userFunction( 'current_user_can' )->andReturn( false );
+		WP_Mock::passthruFunction( 'esc_url' );
+		WP_Mock::passthruFunction( 'esc_attr' );
+
+		$manager = $this->getMockBuilder( Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		ob_start();
+		$manager->render_script();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'data-do-not-track', $output );
+	}
+
+	/**
+	 * Test render_script outputs data-tag when tag option is set.
+	 *
+	 * This test WILL FAIL until we implement the tag attribute.
+	 */
+	public function test_render_script_includes_data_tag() {
+		$test_options = array(
+			'enabled'        => 1,
+			'script_url'     => 'https://stats.example.com/script.js',
+			'website_id'     => 'test-id',
+			'host_url'       => '',
+			'use_host_url'   => 0,
+			'ignore_admins'  => 0,
+			'auto_track'     => 1,
+			'do_not_track'   => 0,
+			'cache'          => 0,
+			'track_comments' => 0,
+			'tag'            => 'my-ab-test',
+			'domains'        => '',
+			'exclude_search' => 0,
+			'exclude_hash'   => 0,
+			'before_send'    => '',
+		);
+
+		WP_Mock::userFunction( 'get_option' )->andReturn( $test_options );
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+		WP_Mock::userFunction( 'current_user_can' )->andReturn( false );
+		WP_Mock::passthruFunction( 'esc_url' );
+		WP_Mock::passthruFunction( 'esc_attr' );
+
+		$manager = $this->getMockBuilder( Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		ob_start();
+		$manager->render_script();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'data-tag="my-ab-test"', $output );
+	}
+
+	/**
+	 * Test render_script outputs data-domains when domains option is set.
+	 *
+	 * This test WILL FAIL until we implement the domains attribute.
+	 */
+	public function test_render_script_includes_data_domains() {
+		$test_options = array(
+			'enabled'        => 1,
+			'script_url'     => 'https://stats.example.com/script.js',
+			'website_id'     => 'test-id',
+			'host_url'       => '',
+			'use_host_url'   => 0,
+			'ignore_admins'  => 0,
+			'auto_track'     => 1,
+			'do_not_track'   => 0,
+			'cache'          => 0,
+			'track_comments' => 0,
+			'tag'            => '',
+			'domains'        => 'example.com,www.example.com',
+			'exclude_search' => 0,
+			'exclude_hash'   => 0,
+			'before_send'    => '',
+		);
+
+		WP_Mock::userFunction( 'get_option' )->andReturn( $test_options );
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+		WP_Mock::userFunction( 'current_user_can' )->andReturn( false );
+		WP_Mock::passthruFunction( 'esc_url' );
+		WP_Mock::passthruFunction( 'esc_attr' );
+
+		$manager = $this->getMockBuilder( Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		ob_start();
+		$manager->render_script();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'data-domains="example.com,www.example.com"', $output );
+	}
+
+	/**
+	 * Test render_script outputs data-exclude-search when option enabled.
+	 */
+	public function test_render_script_includes_exclude_search() {
+		$test_options = array(
+			'enabled'        => 1,
+			'script_url'     => 'https://stats.example.com/script.js',
+			'website_id'     => 'test-id',
+			'host_url'       => '',
+			'use_host_url'   => 0,
+			'ignore_admins'  => 0,
+			'auto_track'     => 1,
+			'do_not_track'   => 0,
+			'cache'          => 0,
+			'track_comments' => 0,
+			'tag'            => '',
+			'domains'        => '',
+			'exclude_search' => 1,
+			'exclude_hash'   => 0,
+			'before_send'    => '',
+		);
+
+		WP_Mock::userFunction( 'get_option' )->andReturn( $test_options );
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+		WP_Mock::userFunction( 'current_user_can' )->andReturn( false );
+		WP_Mock::passthruFunction( 'esc_url' );
+		WP_Mock::passthruFunction( 'esc_attr' );
+
+		$manager = $this->getMockBuilder( Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		ob_start();
+		$manager->render_script();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'data-exclude-search="true"', $output );
+	}
+
+	/**
+	 * Test render_script outputs data-exclude-hash when option enabled.
+	 */
+	public function test_render_script_includes_exclude_hash() {
+		$test_options = array(
+			'enabled'        => 1,
+			'script_url'     => 'https://stats.example.com/script.js',
+			'website_id'     => 'test-id',
+			'host_url'       => '',
+			'use_host_url'   => 0,
+			'ignore_admins'  => 0,
+			'auto_track'     => 1,
+			'do_not_track'   => 0,
+			'cache'          => 0,
+			'track_comments' => 0,
+			'tag'            => '',
+			'domains'        => '',
+			'exclude_search' => 0,
+			'exclude_hash'   => 1,
+			'before_send'    => '',
+		);
+
+		WP_Mock::userFunction( 'get_option' )->andReturn( $test_options );
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+		WP_Mock::userFunction( 'current_user_can' )->andReturn( false );
+		WP_Mock::passthruFunction( 'esc_url' );
+		WP_Mock::passthruFunction( 'esc_attr' );
+
+		$manager = $this->getMockBuilder( Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		ob_start();
+		$manager->render_script();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'data-exclude-hash="true"', $output );
+	}
+
+	/**
+	 * Test render_script outputs data-before-send when option is set.
+	 */
+	public function test_render_script_includes_before_send() {
+		$test_options = array(
+			'enabled'        => 1,
+			'script_url'     => 'https://stats.example.com/script.js',
+			'website_id'     => 'test-id',
+			'host_url'       => '',
+			'use_host_url'   => 0,
+			'ignore_admins'  => 0,
+			'auto_track'     => 1,
+			'do_not_track'   => 0,
+			'cache'          => 0,
+			'track_comments' => 0,
+			'tag'            => '',
+			'domains'        => '',
+			'exclude_search' => 0,
+			'exclude_hash'   => 0,
+			'before_send'    => 'myFilterFunction',
+		);
+
+		WP_Mock::userFunction( 'get_option' )->andReturn( $test_options );
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+		WP_Mock::userFunction( 'current_user_can' )->andReturn( false );
+		WP_Mock::passthruFunction( 'esc_url' );
+		WP_Mock::passthruFunction( 'esc_attr' );
+
+		$manager = $this->getMockBuilder( Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		ob_start();
+		$manager->render_script();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'data-before-send="myFilterFunction"', $output );
+	}
+
+	/**
+	 * Test render_script skips tracking for admin users when ignore_admins enabled.
+	 */
+	public function test_render_script_skips_admin_users() {
+		$test_options = array(
+			'enabled'        => 1,
+			'script_url'     => 'https://stats.example.com/script.js',
+			'website_id'     => 'test-id',
+			'host_url'       => '',
+			'use_host_url'   => 0,
+			'ignore_admins'  => 1,
+			'auto_track'     => 1,
+			'do_not_track'   => 0,
+			'cache'          => 0,
+			'track_comments' => 0,
+			'tag'            => '',
+			'domains'        => '',
+			'exclude_search' => 0,
+			'exclude_hash'   => 0,
+			'before_send'    => '',
+		);
+
+		WP_Mock::userFunction( 'get_option' )->andReturn( $test_options );
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+		WP_Mock::userFunction( 'current_user_can' )
+			->with( 'manage_options' )
+			->andReturn( true );
+
+		$manager = $this->getMockBuilder( Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		ob_start();
+		$manager->render_script();
+		$output = ob_get_clean();
+
+		// Admin user — should output nothing.
+		$this->assertEmpty( trim( $output ) );
+	}
+
+	/**
+	 * Test render_script trims whitespace from script_url and website_id.
+	 *
+	 * This addresses issue #28 — copy-paste whitespace causing tracking failure.
+	 */
+	public function test_render_script_trims_whitespace_from_values() {
+		$test_options = array(
+			'enabled'        => 1,
+			'script_url'     => '  https://stats.example.com/script.js  ',
+			'website_id'     => "  abc-123  \n",
+			'host_url'       => '',
+			'use_host_url'   => 0,
+			'ignore_admins'  => 0,
+			'auto_track'     => 1,
+			'do_not_track'   => 0,
+			'cache'          => 0,
+			'track_comments' => 0,
+			'tag'            => '',
+			'domains'        => '',
+			'exclude_search' => 0,
+			'exclude_hash'   => 0,
+			'before_send'    => '',
+		);
+
+		WP_Mock::userFunction( 'get_option' )->andReturn( $test_options );
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+		WP_Mock::userFunction( 'current_user_can' )->andReturn( false );
+		WP_Mock::passthruFunction( 'esc_url' );
+		WP_Mock::passthruFunction( 'esc_attr' );
+
+		$manager = $this->getMockBuilder( Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		ob_start();
+		$manager->render_script();
+		$output = ob_get_clean();
+
+		// Values should be trimmed — no leading/trailing whitespace in attributes.
+		$this->assertStringContainsString( 'src="https://stats.example.com/script.js"', $output );
+		$this->assertStringContainsString( 'data-website-id="abc-123"', $output );
+		$this->assertStringNotContainsString( '  https://', $output );
+	}
+
+	/**
+	 * Test render_comment_tracking_script outputs JS snippet for comment forms.
+	 *
+	 * The new JS-based approach replaces the fragile PHP regex method that
+	 * broke with custom themes and comment plugins (#39).
+	 */
+	public function test_render_comment_tracking_script_outputs_js() {
+		$manager = $this->getMockBuilder( Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		ob_start();
+		$manager->render_comment_tracking_script();
+		$output = ob_get_clean();
+
+		// Must contain a script tag.
+		$this->assertStringContainsString( '<script', $output );
+
+		// Must target the comment form by standard WP ID.
+		$this->assertStringContainsString( 'commentform', $output );
+
+		// Must set data-umami-event attribute.
+		$this->assertStringContainsString( 'data-umami-event', $output );
+		$this->assertStringContainsString( 'comment', $output );
+	}
+
+	/**
+	 * Test render_script includes host_url when use_host_url enabled.
+	 */
+	public function test_render_script_includes_host_url() {
+		$test_options = array(
+			'enabled'        => 1,
+			'script_url'     => 'https://stats.example.com/script.js',
+			'website_id'     => 'test-id',
+			'host_url'       => 'https://proxy.example.com',
+			'use_host_url'   => 1,
+			'ignore_admins'  => 0,
+			'auto_track'     => 1,
+			'do_not_track'   => 0,
+			'cache'          => 0,
+			'track_comments' => 0,
+			'tag'            => '',
+			'domains'        => '',
+			'exclude_search' => 0,
+			'exclude_hash'   => 0,
+			'before_send'    => '',
+		);
+
+		WP_Mock::userFunction( 'get_option' )->andReturn( $test_options );
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+		WP_Mock::userFunction( 'current_user_can' )->andReturn( false );
+		WP_Mock::passthruFunction( 'esc_url' );
+		WP_Mock::passthruFunction( 'esc_attr' );
+
+		$manager = $this->getMockBuilder( Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		ob_start();
+		$manager->render_script();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'data-host-url="https://proxy.example.com"', $output );
+	}
+}

--- a/tests/phpunit/unit/OptionsTest.php
+++ b/tests/phpunit/unit/OptionsTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Unit tests for the Options class.
+ *
+ * @package Integrate_Umami
+ */
+
+namespace Ancozockt\Umami\Tests;
+
+use WP_Mock;
+use WP_Mock\Tools\TestCase;
+use Ancozockt\Umami\Options;
+
+/**
+ * Tests for Options class.
+ */
+class OptionsTest extends TestCase {
+
+	/**
+	 * Test that get_options returns correct defaults for a fresh install.
+	 */
+	public function test_get_options_returns_defaults_for_new_install() {
+		// Stub migration check: no old options exist.
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'integrate_umami_options' )
+			->andReturn( false );
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'umami_options' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+
+		$options = Options::get_options();
+
+		$this->assertIsArray( $options );
+		$this->assertSame( 0, $options['enabled'] );
+		$this->assertSame( '', $options['script_url'] );
+		$this->assertSame( '', $options['website_id'] );
+		$this->assertSame( '', $options['host_url'] );
+		$this->assertSame( 0, $options['use_host_url'] );
+		$this->assertSame( 1, $options['ignore_admins'] );
+		$this->assertSame( 1, $options['auto_track'] );
+		$this->assertSame( 1, $options['do_not_track'] );
+		$this->assertSame( 0, $options['cache'] );
+		$this->assertSame( 0, $options['track_comments'] );
+	}
+
+	/**
+	 * Test that get_options includes new v3 option defaults.
+	 *
+	 * This test WILL FAIL until we add the new option keys.
+	 */
+	public function test_get_options_includes_v3_defaults() {
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'integrate_umami_options' )
+			->andReturn( false );
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'umami_options' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+
+		$options = Options::get_options();
+
+		// v3 tracker attributes.
+		$this->assertArrayHasKey( 'tag', $options );
+		$this->assertSame( '', $options['tag'] );
+		$this->assertArrayHasKey( 'domains', $options );
+		$this->assertSame( '', $options['domains'] );
+		$this->assertArrayHasKey( 'exclude_search', $options );
+		$this->assertSame( 0, $options['exclude_search'] );
+		$this->assertArrayHasKey( 'exclude_hash', $options );
+		$this->assertSame( 0, $options['exclude_hash'] );
+		$this->assertArrayHasKey( 'before_send', $options );
+		$this->assertSame( '', $options['before_send'] );
+	}
+
+	/**
+	 * Test that migrate_options moves old umami_options to new key.
+	 *
+	 * The migration flow:
+	 * 1. maybe_migrate_options() checks get_option('integrate_umami_options') → empty
+	 * 2. Checks get_option('umami_options') → has old data
+	 * 3. Calls update_option('integrate_umami_options', old_data)
+	 * 4. Calls delete_option('umami_options')
+	 * 5. get_options() then calls get_option('integrate_umami_options') for wp_parse_args
+	 *    — after migration, this should return the migrated data
+	 */
+	public function test_migration_from_old_options() {
+		$old_options = array(
+			'enabled'    => 1,
+			'script_url' => 'https://stats.example.com/umami.js',
+			'website_id' => 'test-id-123',
+		);
+
+		// Track state: after update_option, get_option should return the migrated data.
+		$migrated = false;
+
+		WP_Mock::userFunction( 'get_option' )
+			->andReturnUsing(
+				function ( $key ) use ( $old_options, &$migrated ) {
+					if ( 'integrate_umami_options' === $key ) {
+						// Before migration: empty. After: returns migrated data.
+						return $migrated ? $old_options : false;
+					}
+					if ( 'umami_options' === $key ) {
+						return $old_options;
+					}
+					return false;
+				}
+			);
+
+		WP_Mock::userFunction( 'update_option' )
+			->andReturnUsing(
+				function () use ( &$migrated ) {
+					$migrated = true;
+					return true;
+				}
+			);
+
+		WP_Mock::userFunction( 'delete_option' )->andReturn( true );
+
+		WP_Mock::userFunction( 'wp_parse_args' )
+			->andReturnUsing(
+				function ( $args, $defaults ) {
+					return array_merge( $defaults, is_array( $args ) ? $args : array() );
+				}
+			);
+
+		$options = Options::get_options();
+
+		$this->assertTrue( $migrated, 'Migration should have been triggered' );
+		$this->assertSame( 1, $options['enabled'] );
+		$this->assertSame( 'https://stats.example.com/umami.js', $options['script_url'] );
+	}
+
+	/**
+	 * Test that delete_options removes both old and new option keys.
+	 */
+	public function test_delete_options_removes_both_keys() {
+		WP_Mock::userFunction( 'get_option' )
+			->with( 'umami_options' )
+			->andReturn( array( 'enabled' => 1 ) );
+
+		WP_Mock::userFunction( 'delete_option' )
+			->with( 'umami_options' )
+			->once();
+
+		WP_Mock::userFunction( 'delete_option' )
+			->with( 'integrate_umami_options' )
+			->once();
+
+		Options::delete_options();
+
+		// Assertions are in the WP_Mock expectation counts.
+		$this->assertConditionsMet();
+	}
+}

--- a/tests/phpunit/unit/SettingsTest.php
+++ b/tests/phpunit/unit/SettingsTest.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Unit tests for the Settings class.
+ *
+ * @package Integrate_Umami
+ */
+
+namespace Ancozockt\Umami\Tests;
+
+use WP_Mock;
+use WP_Mock\Tools\TestCase;
+use Ancozockt\Umami\Settings;
+
+/**
+ * Tests for Settings class — option validation and sanitization.
+ */
+class SettingsTest extends TestCase {
+
+	/**
+	 * Test validate_options sanitizes all input fields correctly.
+	 */
+	public function test_validate_options_sanitizes_basic_fields() {
+		WP_Mock::userFunction( 'esc_url_raw' )
+			->andReturnUsing( function ( $url ) {
+				return filter_var( trim( $url ), FILTER_SANITIZE_URL );
+			} );
+		WP_Mock::userFunction( 'sanitize_text_field' )
+			->andReturnUsing( function ( $str ) {
+				return trim( strip_tags( $str ) );
+			} );
+
+		$settings = $this->getMockBuilder( Settings::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		$input = array(
+			'enabled'        => '1',
+			'script_url'     => 'https://stats.example.com/script.js',
+			'website_id'     => 'abc-123-def',
+			'host_url'       => 'https://proxy.example.com',
+			'use_host_url'   => '1',
+			'ignore_admins'  => '1',
+			'auto_track'     => '1',
+			'do_not_track'   => '0',
+			'cache'          => '0',
+			'track_comments' => '1',
+		);
+
+		$result = $settings->validate_options( $input );
+
+		$this->assertSame( 1, $result['enabled'] );
+		$this->assertIsString( $result['script_url'] );
+		$this->assertSame( 'abc-123-def', $result['website_id'] );
+		$this->assertSame( 1, $result['use_host_url'] );
+		$this->assertSame( 1, $result['track_comments'] );
+	}
+
+	/**
+	 * Test validate_options returns empty array for empty input.
+	 */
+	public function test_validate_options_handles_empty_input() {
+		$settings = $this->getMockBuilder( Settings::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		$result = $settings->validate_options( array() );
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * Test validate_options handles v3 fields (tag, domains, etc.).
+	 *
+	 * This test WILL FAIL until we add v3 field validation.
+	 */
+	public function test_validate_options_sanitizes_v3_fields() {
+		WP_Mock::userFunction( 'esc_url_raw' )
+			->andReturnUsing( function ( $url ) {
+				return filter_var( trim( $url ), FILTER_SANITIZE_URL );
+			} );
+		WP_Mock::userFunction( 'sanitize_text_field' )
+			->andReturnUsing( function ( $str ) {
+				return trim( strip_tags( $str ) );
+			} );
+
+		$settings = $this->getMockBuilder( Settings::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		$input = array(
+			'enabled'        => '1',
+			'script_url'     => 'https://stats.example.com/script.js',
+			'website_id'     => 'abc-123',
+			'host_url'       => '',
+			'use_host_url'   => '0',
+			'ignore_admins'  => '1',
+			'auto_track'     => '1',
+			'do_not_track'   => '0',
+			'cache'          => '0',
+			'track_comments' => '0',
+			'tag'            => 'my-tag',
+			'domains'        => 'example.com,www.example.com',
+			'exclude_search' => '1',
+			'exclude_hash'   => '1',
+			'before_send'    => 'myHandler',
+		);
+
+		$result = $settings->validate_options( $input );
+
+		$this->assertArrayHasKey( 'tag', $result );
+		$this->assertSame( 'my-tag', $result['tag'] );
+		$this->assertArrayHasKey( 'domains', $result );
+		$this->assertSame( 'example.com,www.example.com', $result['domains'] );
+		$this->assertArrayHasKey( 'exclude_search', $result );
+		$this->assertSame( 1, $result['exclude_search'] );
+		$this->assertArrayHasKey( 'exclude_hash', $result );
+		$this->assertSame( 1, $result['exclude_hash'] );
+		$this->assertArrayHasKey( 'before_send', $result );
+		$this->assertSame( 'myHandler', $result['before_send'] );
+	}
+
+	/**
+	 * Test validate_options rejects invalid before_send function names.
+	 *
+	 * Only valid JS identifiers should be allowed.
+	 */
+	public function test_validate_options_rejects_invalid_before_send() {
+		WP_Mock::userFunction( 'esc_url_raw' )
+			->andReturnUsing( function ( $url ) {
+				return filter_var( trim( $url ), FILTER_SANITIZE_URL );
+			} );
+		WP_Mock::userFunction( 'sanitize_text_field' )
+			->andReturnUsing( function ( $str ) {
+				return trim( strip_tags( $str ) );
+			} );
+
+		$settings = $this->getMockBuilder( Settings::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		$input = array(
+			'enabled'        => '1',
+			'script_url'     => 'https://stats.example.com/script.js',
+			'website_id'     => 'abc-123',
+			'host_url'       => '',
+			'use_host_url'   => '0',
+			'ignore_admins'  => '1',
+			'auto_track'     => '1',
+			'do_not_track'   => '0',
+			'cache'          => '0',
+			'track_comments' => '0',
+			'tag'            => '',
+			'domains'        => '',
+			'exclude_search' => '0',
+			'exclude_hash'   => '0',
+			'before_send'    => 'alert("xss")',
+		);
+
+		$result = $settings->validate_options( $input );
+
+		// Invalid JS function name — should be sanitized to empty.
+		$this->assertSame( '', $result['before_send'] );
+	}
+
+	/**
+	 * Test validate_options trims whitespace from script_url and website_id.
+	 *
+	 * Addresses issue #28 — copy-paste whitespace breaking tracking.
+	 */
+	public function test_validate_options_trims_whitespace() {
+		WP_Mock::userFunction( 'esc_url_raw' )
+			->andReturnUsing( function ( $url ) {
+				return filter_var( trim( $url ), FILTER_SANITIZE_URL );
+			} );
+		WP_Mock::userFunction( 'sanitize_text_field' )
+			->andReturnUsing( function ( $str ) {
+				return trim( strip_tags( $str ) );
+			} );
+
+		$settings = $this->getMockBuilder( Settings::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array() )
+			->getMock();
+
+		$input = array(
+			'enabled'        => '1',
+			'script_url'     => "  https://stats.example.com/script.js \n",
+			'website_id'     => "  abc-123  \t",
+			'host_url'       => '',
+			'use_host_url'   => '0',
+			'ignore_admins'  => '1',
+			'auto_track'     => '1',
+			'do_not_track'   => '0',
+			'cache'          => '0',
+			'track_comments' => '0',
+		);
+
+		$result = $settings->validate_options( $input );
+
+		// esc_url_raw and sanitize_text_field both trim, but validate_options
+		// should also explicitly trim before passing to sanitizers.
+		$this->assertStringNotContainsString( "\n", $result['script_url'] );
+		$this->assertStringNotContainsString( "\t", $result['website_id'] );
+		$this->assertStringNotContainsString( '  ', $result['script_url'] );
+	}
+}

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -11,6 +11,11 @@ test.describe('settings page', () => {
         await page.locator('#integrate_umami_enabled').check();
         await page.locator('#integrate_umami_script_url').fill('https://umami.example.com/umami.js')
         await page.locator('#integrate_umami_website_id').fill('12345678')
+
+        // Expand advanced options and enable do-not-track.
+        await page.locator('label[for="advanced-options"]').click();
+        await page.locator('#integrate_umami_do_not_track').check();
+
         await page.getByRole('button', {name: 'Save Changes'}).click();
 
         await logout(page);

--- a/tests/v3-attributes.test.js
+++ b/tests/v3-attributes.test.js
@@ -1,0 +1,243 @@
+const {test, expect} = require('@playwright/test')
+const {runCommand, updateOption} = require("./helper/wpcli-command");
+
+/**
+ * E2E tests for v3 tracker attributes using the live Umami instance
+ * at stats.wavedepth.com. These tests verify the plugin correctly
+ * renders all v3-specific data attributes on the tracking script tag.
+ */
+
+const LIVE_UMAMI_SCRIPT = 'https://stats.wavedepth.com/script.js'
+const LIVE_WEBSITE_ID = '837d5df1-a19a-4cac-831c-34a53ab951b5' // wavedepth.com
+
+test.describe('v3 tracker attributes', () => {
+
+    test.beforeEach(async ({page}) => {
+        // Reset options to a known state before each test.
+        updateOption('integrate_umami_options', {
+            enabled: 1,
+            script_url: LIVE_UMAMI_SCRIPT,
+            website_id: LIVE_WEBSITE_ID,
+            host_url: 'https://stats.wavedepth.com',
+            use_host_url: 0,
+            ignore_admins: 0,
+            auto_track: 1,
+            do_not_track: 0,
+            cache: 0,
+            track_comments: 0,
+            tag: '',
+            domains: '',
+            exclude_search: 0,
+            exclude_hash: 0,
+            before_send: ''
+        });
+    });
+
+    test('renders live Umami tracking script with correct src and website ID', async ({page}) => {
+        await page.goto('/', {waitUntil: 'networkidle'});
+
+        const script = page.locator(`script[src='${LIVE_UMAMI_SCRIPT}']`);
+        await expect(script).toBeAttached();
+        await expect(script).toHaveAttribute('async', '');
+        await expect(script).toHaveAttribute('defer', '');
+        await expect(script).toHaveAttribute('data-website-id', LIVE_WEBSITE_ID);
+    });
+
+    test('renders data-tag attribute when tag is set', async ({page}) => {
+        updateOption('integrate_umami_options', {
+            enabled: 1,
+            script_url: LIVE_UMAMI_SCRIPT,
+            website_id: LIVE_WEBSITE_ID,
+            host_url: '',
+            use_host_url: 0,
+            ignore_admins: 0,
+            auto_track: 1,
+            do_not_track: 0,
+            cache: 0,
+            track_comments: 0,
+            tag: 'wp-test-tag',
+            domains: '',
+            exclude_search: 0,
+            exclude_hash: 0,
+            before_send: ''
+        });
+
+        await page.goto('/', {waitUntil: 'networkidle'});
+
+        const script = page.locator(`script[src='${LIVE_UMAMI_SCRIPT}']`);
+        await expect(script).toHaveAttribute('data-tag', 'wp-test-tag');
+    });
+
+    test('renders data-domains attribute with comma-separated values', async ({page}) => {
+        updateOption('integrate_umami_options', {
+            enabled: 1,
+            script_url: LIVE_UMAMI_SCRIPT,
+            website_id: LIVE_WEBSITE_ID,
+            host_url: '',
+            use_host_url: 0,
+            ignore_admins: 0,
+            auto_track: 1,
+            do_not_track: 0,
+            cache: 0,
+            track_comments: 0,
+            tag: '',
+            domains: 'localhost,wavedepth.com',
+            exclude_search: 0,
+            exclude_hash: 0,
+            before_send: ''
+        });
+
+        await page.goto('/', {waitUntil: 'networkidle'});
+
+        const script = page.locator(`script[src='${LIVE_UMAMI_SCRIPT}']`);
+        await expect(script).toHaveAttribute('data-domains', 'localhost,wavedepth.com');
+    });
+
+    test('renders data-exclude-search when enabled', async ({page}) => {
+        updateOption('integrate_umami_options', {
+            enabled: 1,
+            script_url: LIVE_UMAMI_SCRIPT,
+            website_id: LIVE_WEBSITE_ID,
+            host_url: '',
+            use_host_url: 0,
+            ignore_admins: 0,
+            auto_track: 1,
+            do_not_track: 0,
+            cache: 0,
+            track_comments: 0,
+            tag: '',
+            domains: '',
+            exclude_search: 1,
+            exclude_hash: 0,
+            before_send: ''
+        });
+
+        await page.goto('/', {waitUntil: 'networkidle'});
+
+        const script = page.locator(`script[src='${LIVE_UMAMI_SCRIPT}']`);
+        await expect(script).toHaveAttribute('data-exclude-search', 'true');
+    });
+
+    test('renders data-exclude-hash when enabled', async ({page}) => {
+        updateOption('integrate_umami_options', {
+            enabled: 1,
+            script_url: LIVE_UMAMI_SCRIPT,
+            website_id: LIVE_WEBSITE_ID,
+            host_url: '',
+            use_host_url: 0,
+            ignore_admins: 0,
+            auto_track: 1,
+            do_not_track: 0,
+            cache: 0,
+            track_comments: 0,
+            tag: '',
+            domains: '',
+            exclude_search: 0,
+            exclude_hash: 1,
+            before_send: ''
+        });
+
+        await page.goto('/', {waitUntil: 'networkidle'});
+
+        const script = page.locator(`script[src='${LIVE_UMAMI_SCRIPT}']`);
+        await expect(script).toHaveAttribute('data-exclude-hash', 'true');
+    });
+
+    test('renders data-before-send with function name', async ({page}) => {
+        updateOption('integrate_umami_options', {
+            enabled: 1,
+            script_url: LIVE_UMAMI_SCRIPT,
+            website_id: LIVE_WEBSITE_ID,
+            host_url: '',
+            use_host_url: 0,
+            ignore_admins: 0,
+            auto_track: 1,
+            do_not_track: 0,
+            cache: 0,
+            track_comments: 0,
+            tag: '',
+            domains: '',
+            exclude_search: 0,
+            exclude_hash: 0,
+            before_send: 'myBeforeSend'
+        });
+
+        await page.goto('/', {waitUntil: 'networkidle'});
+
+        const script = page.locator(`script[src='${LIVE_UMAMI_SCRIPT}']`);
+        await expect(script).toHaveAttribute('data-before-send', 'myBeforeSend');
+    });
+
+    test('renders data-host-url with proper quoting when enabled', async ({page}) => {
+        updateOption('integrate_umami_options', {
+            enabled: 1,
+            script_url: LIVE_UMAMI_SCRIPT,
+            website_id: LIVE_WEBSITE_ID,
+            host_url: 'https://stats.wavedepth.com',
+            use_host_url: 1,
+            ignore_admins: 0,
+            auto_track: 1,
+            do_not_track: 0,
+            cache: 0,
+            track_comments: 0,
+            tag: '',
+            domains: '',
+            exclude_search: 0,
+            exclude_hash: 0,
+            before_send: ''
+        });
+
+        await page.goto('/', {waitUntil: 'networkidle'});
+
+        const script = page.locator(`script[src='${LIVE_UMAMI_SCRIPT}']`);
+        await expect(script).toHaveAttribute('data-host-url', 'https://stats.wavedepth.com');
+    });
+
+    test('does NOT render absent v3 attributes when options are empty', async ({page}) => {
+        await page.goto('/', {waitUntil: 'networkidle'});
+
+        const script = page.locator(`script[src='${LIVE_UMAMI_SCRIPT}']`);
+        await expect(script).toBeAttached();
+
+        // These attributes should NOT be present when options are empty/disabled.
+        const html = await script.evaluate(el => el.outerHTML);
+        expect(html).not.toContain('data-tag');
+        expect(html).not.toContain('data-domains');
+        expect(html).not.toContain('data-exclude-search');
+        expect(html).not.toContain('data-exclude-hash');
+        expect(html).not.toContain('data-before-send');
+        expect(html).not.toContain('data-cache');
+    });
+
+    test('renders all v3 attributes simultaneously', async ({page}) => {
+        updateOption('integrate_umami_options', {
+            enabled: 1,
+            script_url: LIVE_UMAMI_SCRIPT,
+            website_id: LIVE_WEBSITE_ID,
+            host_url: 'https://stats.wavedepth.com',
+            use_host_url: 1,
+            ignore_admins: 0,
+            auto_track: 1,
+            do_not_track: 1,
+            cache: 0,
+            track_comments: 0,
+            tag: 'full-test',
+            domains: 'localhost',
+            exclude_search: 1,
+            exclude_hash: 1,
+            before_send: 'filterPayload'
+        });
+
+        await page.goto('/', {waitUntil: 'networkidle'});
+
+        const script = page.locator(`script[src='${LIVE_UMAMI_SCRIPT}']`);
+        await expect(script).toHaveAttribute('data-website-id', LIVE_WEBSITE_ID);
+        await expect(script).toHaveAttribute('data-do-not-track', 'true');
+        await expect(script).toHaveAttribute('data-host-url', 'https://stats.wavedepth.com');
+        await expect(script).toHaveAttribute('data-tag', 'full-test');
+        await expect(script).toHaveAttribute('data-domains', 'localhost');
+        await expect(script).toHaveAttribute('data-exclude-search', 'true');
+        await expect(script).toHaveAttribute('data-exclude-hash', 'true');
+        await expect(script).toHaveAttribute('data-before-send', 'filterPayload');
+    });
+});

--- a/tests/v3-settings.test.js
+++ b/tests/v3-settings.test.js
@@ -1,0 +1,138 @@
+const {test, expect} = require('@playwright/test')
+const {updateOption, getOption, runCommand} = require("./helper/wpcli-command");
+const TEST_USER = process.env.TEST_USER || 'admin'
+const TEST_PASS = process.env.TEST_PASS || 'password'
+
+/**
+ * E2E tests for the v3 settings fields on the admin settings page.
+ * Verifies that all new v3 fields are visible, saveable, and persist correctly.
+ */
+
+test.describe('v3 settings fields', () => {
+
+    test.beforeEach(async ({page}) => {
+        // Reset to baseline options.
+        updateOption('integrate_umami_options', {
+            enabled: 1,
+            script_url: 'https://stats.wavedepth.com/script.js',
+            website_id: '837d5df1-a19a-4cac-831c-34a53ab951b5',
+            host_url: '',
+            use_host_url: 0,
+            ignore_admins: 0,
+            auto_track: 1,
+            do_not_track: 0,
+            cache: 0,
+            track_comments: 0,
+            tag: '',
+            domains: '',
+            exclude_search: 0,
+            exclude_hash: 0,
+            before_send: ''
+        });
+        await login(page);
+        await switchToSettings(page);
+    });
+
+    test('v3 settings fields are present in the admin UI', async ({page}) => {
+        // Expand advanced options.
+        await page.locator('label[for="advanced-options"]').click();
+
+        // Verify v3 fields exist.
+        await expect(page.locator('#integrate_umami_tag')).toBeVisible();
+        await expect(page.locator('#integrate_umami_domains')).toBeVisible();
+        await expect(page.locator('#integrate_umami_exclude_search')).toBeVisible();
+        await expect(page.locator('#integrate_umami_exclude_hash')).toBeVisible();
+        await expect(page.locator('#integrate_umami_before_send')).toBeVisible();
+    });
+
+    test('saves tag field via settings page', async ({page}) => {
+        await page.locator('label[for="advanced-options"]').click();
+
+        await page.locator('#integrate_umami_tag').fill('my-ab-test');
+        await page.getByRole('button', {name: 'Save Changes'}).click();
+
+        // Verify saved in database.
+        const options = getOption('integrate_umami_options');
+        expect(options.tag).toBe('my-ab-test');
+    });
+
+    test('saves domains field via settings page', async ({page}) => {
+        await page.locator('label[for="advanced-options"]').click();
+
+        await page.locator('#integrate_umami_domains').fill('example.com,test.com');
+        await page.getByRole('button', {name: 'Save Changes'}).click();
+
+        const options = getOption('integrate_umami_options');
+        expect(options.domains).toBe('example.com,test.com');
+    });
+
+    test('saves exclude_search checkbox via settings page', async ({page}) => {
+        await page.locator('label[for="advanced-options"]').click();
+
+        await page.locator('#integrate_umami_exclude_search').check();
+        await page.getByRole('button', {name: 'Save Changes'}).click();
+
+        const options = getOption('integrate_umami_options');
+        expect(options.exclude_search).toBe(1);
+    });
+
+    test('saves exclude_hash checkbox via settings page', async ({page}) => {
+        await page.locator('label[for="advanced-options"]').click();
+
+        await page.locator('#integrate_umami_exclude_hash').check();
+        await page.getByRole('button', {name: 'Save Changes'}).click();
+
+        const options = getOption('integrate_umami_options');
+        expect(options.exclude_hash).toBe(1);
+    });
+
+    test('saves before_send field via settings page', async ({page}) => {
+        await page.locator('label[for="advanced-options"]').click();
+
+        await page.locator('#integrate_umami_before_send').fill('myFilterFn');
+        await page.getByRole('button', {name: 'Save Changes'}).click();
+
+        const options = getOption('integrate_umami_options');
+        expect(options.before_send).toBe('myFilterFn');
+    });
+
+    test('shows cache deprecation notice', async ({page}) => {
+        await page.locator('label[for="advanced-options"]').click();
+
+        const deprecatedLabel = page.locator('text=Deprecated');
+        await expect(deprecatedLabel.first()).toBeVisible();
+    });
+
+    test('shows Umami Cloud helper text in script URL field', async ({page}) => {
+        const cloudHelp = page.locator('text=cloud.umami.is/script.js');
+        await expect(cloudHelp).toBeVisible();
+    });
+});
+
+async function login(page) {
+    await page.goto('/wp-login.php', {waitUntil: 'networkidle'})
+    await expect(page).toHaveTitle(/Log In/)
+
+    await page.fill('#user_login', TEST_USER)
+    await page.fill('#user_pass', TEST_PASS)
+    await page.click('#wp-submit')
+
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveTitle(/Dashboard/)
+}
+
+async function switchToSettings(page) {
+    const menu = await page.locator('.wp-menu-name').getByText('Settings')
+    await expect(menu).toBeVisible();
+    await menu.click()
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveTitle(/General Settings/)
+
+    const settings = await page.locator('a').getByText('Integrate Umami')
+    await expect(settings).toBeVisible();
+    await settings.click()
+    await page.waitForLoadState('networkidle')
+
+    const title = await page.locator('h1').getByText('Integrate Umami Settings')
+    await expect(title).toBeVisible()
+}


### PR DESCRIPTION
## Summary

- **v3 tracker attributes**: Added `data-tag`, `data-domains`, `data-exclude-search`, `data-exclude-hash`, `data-before-send` with settings UI, validation, and rendering
- **Bug fixes**: Fixed `esc_attr_e` misuse (#28), whitespace trimming (#28), comment tracking (#39), Umami Cloud help text (#35), auto-tracking description (#52)
- **API client**: New `class-api-client.php` with dual auth (Cloud API key via `x-umami-api-key` header + self-hosted token via `/api/auth/login`)
- **Dashboard widget**: Enhanced with live stats (pageviews, visitors, active now) fetched via API with 5-minute transient cache
- **Settings page**: v3 fields, API connection section, cache deprecation notice, improved help text
- **Test suite**: 32 PHPUnit unit tests + 27 Playwright E2E tests (tested against live Umami v3 instance)

### Issues Addressed
- Fixes #28 — Stats not sending (esc_attr_e bug + whitespace)
- Fixes #35 — Script URL for Umami Cloud unclear
- Fixes #39 — Comments don't show up in events
- Fixes #52 — Which events are auto-tracked?
- Fixes #53 — How to set data-tag?
- Addresses #4 — Use Umami API for fetching info
- Addresses #24 — Improve settings page

### Files Changed

| File | Change |
|------|--------|
| `inc/class-api-client.php` | **New** — Umami API client |
| `inc/class-manager.php` | v3 attrs, JS comment tracking, whitespace fix |
| `inc/class-options.php` | v3 + API option defaults |
| `inc/class-settings.php` | v3 + API field validation |
| `inc/class-dashboard-widget.php` | Live stats via API |
| `inc/templates/settings-page.php` | v3 fields, API section, help text |
| `tests/phpunit/unit/*.php` | 32 unit tests (4 files) |
| `tests/*.test.js` | 27 E2E tests (4 new files + 1 fix) |
| `tests/helper/wpcli-command.js` | JSON-safe updateOption/getOption helpers |
| `CONTRIBUTION_PLAN.md` | Comprehensive contribution plan |

### Backwards Compatibility
- All v3 attributes are ignored by v2 tracker scripts (no harm)
- `data-cache` preserved but deprecated with notice
- Options migration from old key preserved
- API connection is optional — plugin works without it

## Test plan
- [x] 32 PHPUnit unit tests pass (Options, Manager, Settings, ApiClient)
- [x] 27 Playwright E2E tests pass against live Umami v3 instance
- [x] All v3 data attributes render correctly on frontend
- [x] Settings page saves and loads all v3 fields
- [x] Comment tracking JS injects on posts with comments enabled
- [x] Dashboard widget shows link (without API creds) and stats (with API creds)
- [x] Cache deprecation notice visible in admin
- [x] Umami Cloud helper text visible in script URL field
- [ ] Test with Umami v2 instance for backwards compatibility
- [ ] Test with WooCommerce active (no conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)